### PR TITLE
Screensaver Controls 

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -10,6 +10,7 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemData.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/VolumeControl.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Gamelist.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemScreenSaver.h
 
     # GuiComponents
     ${CMAKE_CURRENT_SOURCE_DIR}/src/components/AsyncReqComponent.h
@@ -57,6 +58,7 @@ set(ES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemData.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/VolumeControl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Gamelist.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemScreenSaver.cpp
 
     # GuiComponents
     ${CMAKE_CURRENT_SOURCE_DIR}/src/components/AsyncReqComponent.cpp

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -21,9 +21,10 @@ SystemScreenSaver::SystemScreenSaver(Window* window) :
 	mVideoCount(0),
 	mState(STATE_INACTIVE),
 	mOpacity(0.0f),
-	mTimer(0)
 	mTimer(0),
 	mSystemName(NULL),
+	mGameName(NULL),
+	mGameIndex(-1)
 {
 	mWindow->setScreenSaver(this);
 }
@@ -234,6 +235,67 @@ void SystemScreenSaver::update(int deltaTime)
 		mVideoScreensaver->update(deltaTime);
 }
 
+const char* SystemScreenSaver::getSystemName()
 {
 	if (mSystemName)
 		return mSystemName;
+	else
+		return "";
+}
+
+const char* SystemScreenSaver::getGameName() 
+{
+	if (mGameName)
+		return mGameName;
+	else
+		return "";
+}
+
+int SystemScreenSaver::getGameIndex()
+{
+	return mGameIndex;
+}
+
+void SystemScreenSaver::writeSubtitle() 
+{
+	FILE* file = fopen(getTitlePath().c_str(), "w");	
+	fprintf(file, "1\n00:00:01,000 --> 00:00:08,000\n");
+	fprintf(file, "%s\n", getGameName());
+	fprintf(file, "<i>%s</i>\n\n", getSystemName());
+	fprintf(file, "2\n00:00:29,000 --> 00:00:35,000\n");
+	fprintf(file, "%s\n", getGameName());
+	fprintf(file, "<i>%s</i>\n", getSystemName());
+	fflush(file);
+	fclose(file);
+	file = NULL;
+}
+
+void SystemScreenSaver::input(InputConfig* config, Input input)
+{
+	LOG(LogDebug) << "Detected input while screensaver: " <<  input.string() << " Game Index: " << getGameIndex();
+	if(getGameIndex() >= 0 && (config->isMappedTo("right", input) || config->isMappedTo("start", input))) 
+	{
+		LOG(LogDebug) << "Detected right input while video screensaver";
+		if(config->isMappedTo("right", input)) 
+		{
+			LOG(LogDebug) << "Next video!";
+			// handle screensaver control, first stab
+			cancelScreenSaver();
+			startScreenSaver();
+		}
+		else if(config->isMappedTo("start", input)) 
+		{
+			// launch game!
+			LOG(LogDebug) << "Launch Game: " << getGameName() << " - System: " << getSystemName();
+
+			// get game info
+			
+
+			// wake up
+			mTimeSinceLastInput = 0;
+			cancelScreenSaver();
+			mSleeping = false;
+			onWake();
+		}
+	}
+}

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -70,7 +70,7 @@ void SystemScreenSaver::startScreenSaver()
 			// try again
 
 			int retry = 20;
-			while(retry > 0 && (path.empty() || !boost::filesystem::exists(path)))
+			while(retry > 0 && (path.empty() || !boost::filesystem::exists(path)) || mCurrentGame == NULL)
 			{
 				retry--;
 				pickRandomVideo(path);
@@ -180,6 +180,7 @@ void SystemScreenSaver::countVideos()
 void SystemScreenSaver::pickRandomVideo(std::string& path)
 {
 	countVideos();
+	mCurrentGame = NULL;
 	if (mVideoCount > 0)
 	{
 		srand((unsigned int)time(NULL));
@@ -252,13 +253,14 @@ void SystemScreenSaver::pickRandomVideo(std::string& path)
 									{
 										mCurrentGame = (*itf);
 										LOG(LogDebug) << "Found FileData in iteration! " << mCurrentGame->getName();
+										break;
 									}
 								}
 							}
 
 							// end of getting FileData
-
-							writeSubtitle(mSystemName.c_str(), mGameName.c_str());
+							if (Settings::getInstance()->getBool("ScreenSaverGameName"))
+								writeSubtitle(mGameName.c_str(), mSystemName.c_str());
 							return;
 						}
 					}

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -1,0 +1,204 @@
+#include "SystemScreenSaver.h"
+#include "components/VideoComponent.h"
+#include "Renderer.h"
+#include "Settings.h"
+#include "SystemData.h"
+#include "Util.h"
+
+#define FADE_TIME 			3000
+#define SWAP_VIDEO_TIMEOUT	30000
+
+SystemScreenSaver::SystemScreenSaver(Window* window) :
+	mVideoScreensaver(NULL),
+	mWindow(window),
+	mCounted(false),
+	mVideoCount(0),
+	mState(STATE_INACTIVE),
+	mOpacity(0.0f),
+	mTimer(0)
+{
+	mWindow->setScreenSaver(this);
+}
+
+SystemScreenSaver::~SystemScreenSaver()
+{
+	delete mVideoScreensaver;
+}
+
+bool SystemScreenSaver::allowSleep()
+{
+	return false;
+}
+
+void SystemScreenSaver::startScreenSaver()
+{
+	if (!mVideoScreensaver && (Settings::getInstance()->getString("ScreenSaverBehavior") == "random video"))
+	{
+		// Configure to fade out the windows
+		mState = STATE_FADE_OUT_WINDOW;
+		mOpacity = 0.0f;
+
+		// Load a random video
+		std::string path;
+		pickRandomVideo(path);
+		if (!path.empty())
+		{
+			mVideoScreensaver = new VideoComponent(mWindow);
+			mVideoScreensaver->setOrigin(0.0f, 0.0f);
+			mVideoScreensaver->setPosition(0.0f, 0.0f);
+			mVideoScreensaver->setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
+			mVideoScreensaver->setVideo(path);
+			mVideoScreensaver->onShow();
+			mTimer = 0;
+		}
+		else
+		{
+			// No videos. Just use a standard screensaver
+			mState = STATE_SCREENSAVER_ACTIVE;
+		}
+	}
+}
+
+void SystemScreenSaver::stopScreenSaver()
+{
+	delete mVideoScreensaver;
+	mVideoScreensaver = NULL;
+	mState = STATE_INACTIVE;
+}
+
+void SystemScreenSaver::renderScreenSaver()
+{
+	if (mVideoScreensaver)
+	{
+		// Only render the video if the state requires it
+		if ((int)mState >= STATE_FADE_IN_VIDEO)
+		{
+			Eigen::Affine3f transform = Eigen::Affine3f::Identity();
+			mVideoScreensaver->render(transform);
+		}
+		// Handle any fade
+		Renderer::setMatrix(Eigen::Affine3f::Identity());
+		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), (unsigned char)(mOpacity * 255));
+	}
+	else if (mState != STATE_INACTIVE)
+	{
+		Renderer::setMatrix(Eigen::Affine3f::Identity());
+		unsigned char opacity = Settings::getInstance()->getString("ScreenSaverBehavior") == "dim" ? 0xA0 : 0xFF;
+		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), 0x00000000 | opacity);
+	}
+}
+
+void SystemScreenSaver::countVideos()
+{
+	if (!mCounted)
+	{
+		mVideoCount = 0;
+		mCounted = true;
+		std::vector<SystemData*>:: iterator it;
+		for (it = SystemData::sSystemVector.begin(); it != SystemData::sSystemVector.end(); ++it)
+		{
+			pugi::xml_document doc;
+			pugi::xml_node root;
+			std::string xmlReadPath = (*it)->getGamelistPath(false);
+
+			if(boost::filesystem::exists(xmlReadPath))
+			{
+				pugi::xml_parse_result result = doc.load_file(xmlReadPath.c_str());
+				if (!result)
+					continue;
+				root = doc.child("gameList");
+				if (!root)
+					continue;
+				for(pugi::xml_node fileNode = root.child("game"); fileNode; fileNode = fileNode.next_sibling("game"))
+				{
+					pugi::xml_node videoNode = fileNode.child("video");
+					if (videoNode)
+						++mVideoCount;
+				}
+			}
+		}
+	}
+}
+
+void SystemScreenSaver::pickRandomVideo(std::string& path)
+{
+	countVideos();
+	if (mVideoCount > 0)
+	{
+		srand((unsigned int)time(NULL));
+		int video = (int)(((float)rand() / float(RAND_MAX)) * (float)mVideoCount);
+
+		std::vector<SystemData*>:: iterator it;
+		for (it = SystemData::sSystemVector.begin(); it != SystemData::sSystemVector.end(); ++it)
+		{
+			pugi::xml_document doc;
+			pugi::xml_node root;
+			std::string xmlReadPath = (*it)->getGamelistPath(false);
+
+			if(boost::filesystem::exists(xmlReadPath))
+			{
+				pugi::xml_parse_result result = doc.load_file(xmlReadPath.c_str());
+				if (!result)
+					continue;
+				root = doc.child("gameList");
+				if (!root)
+					continue;
+				for(pugi::xml_node fileNode = root.child("game"); fileNode; fileNode = fileNode.next_sibling("game"))
+				{
+					pugi::xml_node videoNode = fileNode.child("video");
+					if (videoNode)
+					{
+						// See if this is the randomly selected video
+						if (video-- == 0)
+						{
+							// Yes. Resolve to a full path
+							path = resolvePath(videoNode.text().get(), (*it)->getStartPath(), true).generic_string();
+							return;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+void SystemScreenSaver::update(int deltaTime)
+{
+	// Use this to update the fade value for the current fade stage
+	if (mState == STATE_FADE_OUT_WINDOW)
+	{
+		mOpacity += (float)deltaTime / FADE_TIME;
+		if (mOpacity >= 1.0f)
+		{
+			mOpacity = 1.0f;
+
+			// Update to the next state
+			mState = STATE_FADE_IN_VIDEO;
+		}
+	}
+	else if (mState == STATE_FADE_IN_VIDEO)
+	{
+		mOpacity -= (float)deltaTime / FADE_TIME;
+		if (mOpacity <= 0.0f)
+		{
+			mOpacity = 0.0f;
+			// Update to the next state
+			mState = STATE_SCREENSAVER_ACTIVE;
+		}
+	}
+	else if (mState == STATE_SCREENSAVER_ACTIVE)
+	{
+		// Update the timer that swaps the videos
+		mTimer += deltaTime;
+		if (mTimer > SWAP_VIDEO_TIMEOUT)
+		{
+			stopScreenSaver();
+			startScreenSaver();
+			mState = STATE_SCREENSAVER_ACTIVE;
+		}
+	}
+
+	// If we have a loaded video then update it
+	if (mVideoScreensaver)
+		mVideoScreensaver->update(deltaTime);
+}

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -329,14 +329,13 @@ FileData* SystemScreenSaver::getCurrentGame()
 	return mCurrentGame;
 }
 
-void SystemScreenSaver::launchGame() {
-
-	bool launchOnStart = true;
+void SystemScreenSaver::launchGame()
+{
 	// launching Game
 	ViewController::get()->goToGameList(mCurrentGame->getSystem());
 	IGameListView* view = ViewController::get()->getGameListView(mCurrentGame->getSystem()).get();
  	view->setCursor(mCurrentGame);
- 	if (launchOnStart) 
+ 	if (Settings::getInstance()->getBool("LaunchOnStart")) 
  	{
  		ViewController::get()->launch(mCurrentGame);
  	}

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -7,9 +7,11 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include "Util.h"
+#include "Log.h"
 
 #define FADE_TIME 			3000
 #define SWAP_VIDEO_TIMEOUT	30000
+//#define SWAP_VIDEO_TIMEOUT	10000
 
 SystemScreenSaver::SystemScreenSaver(Window* window) :
 	mVideoScreensaver(NULL),
@@ -44,6 +46,7 @@ void SystemScreenSaver::startScreenSaver()
 		// Load a random video
 		std::string path;
 		pickRandomVideo(path);
+		LOG(LogInfo) << "Starting Video at path \"" << path << "\"";
 		if (!path.empty())
 		{
 	// Create the correct type of video component
@@ -66,6 +69,7 @@ void SystemScreenSaver::startScreenSaver()
 		}
 		else
 		{
+			LOG(LogError) << "Path is empty! Path: \"" << path << "\"";
 			// No videos. Just use a standard screensaver
 			mState = STATE_SCREENSAVER_ACTIVE;
 		}
@@ -81,6 +85,9 @@ void SystemScreenSaver::stopScreenSaver()
 
 void SystemScreenSaver::renderScreenSaver()
 {
+	float lOpacity = mOpacity;
+	if (Settings::getInstance()->getBool("VideoOmxPlayer"))
+		lOpacity = 1.0f;
 	if (mVideoScreensaver)
 	{
 		// Only render the video if the state requires it
@@ -91,7 +98,7 @@ void SystemScreenSaver::renderScreenSaver()
 		}
 		// Handle any fade
 		Renderer::setMatrix(Eigen::Affine3f::Identity());
-		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), (unsigned char)(mOpacity * 255));
+		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), (unsigned char)(lOpacity * 255));
 	}
 	else if (mState != STATE_INACTIVE)
 	{

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -1,5 +1,8 @@
 #include "SystemScreenSaver.h"
-#include "components/VideoComponent.h"
+#ifdef _RPI_
+#include "components/VideoPlayerComponent.h"
+#endif
+#include "components/VideoVlcComponent.h"
 #include "Renderer.h"
 #include "Settings.h"
 #include "SystemData.h"
@@ -43,7 +46,17 @@ void SystemScreenSaver::startScreenSaver()
 		pickRandomVideo(path);
 		if (!path.empty())
 		{
-			mVideoScreensaver = new VideoComponent(mWindow);
+	// Create the correct type of video component
+#ifdef _RPI_
+			if (Settings::getInstance()->getBool("VideoOmxPlayer"))
+				mVideoScreensaver = new VideoPlayerComponent(mWindow);
+			else
+				mVideoScreensaver = new VideoVlcComponent(mWindow);
+#else
+			mVideoScreensaver = new VideoVlcComponent(mWindow);
+#endif
+
+
 			mVideoScreensaver->setOrigin(0.0f, 0.0f);
 			mVideoScreensaver->setPosition(0.0f, 0.0f);
 			mVideoScreensaver->setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -11,7 +11,6 @@
 
 #define FADE_TIME 			3000
 #define SWAP_VIDEO_TIMEOUT	30000
-//#define SWAP_VIDEO_TIMEOUT	10000
 
 SystemScreenSaver::SystemScreenSaver(Window* window) :
 	mVideoScreensaver(NULL),

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -270,7 +270,7 @@ void SystemScreenSaver::writeSubtitle()
 	file = NULL;
 }
 
-void SystemScreenSaver::input(InputConfig* config, Input input)
+/*void SystemScreenSaver::input(InputConfig* config, Input input)
 {
 	LOG(LogDebug) << "Detected input while screensaver: " <<  input.string() << " Game Index: " << getGameIndex();
 	if(getGameIndex() >= 0 && (config->isMappedTo("right", input) || config->isMappedTo("start", input))) 
@@ -299,3 +299,4 @@ void SystemScreenSaver::input(InputConfig* config, Input input)
 		}
 	}
 }
+*/

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -22,8 +22,8 @@ SystemScreenSaver::SystemScreenSaver(Window* window) :
 	mState(STATE_INACTIVE),
 	mOpacity(0.0f),
 	mTimer(0),
-	mSystemName(NULL),
-	mGameName(NULL),
+	mSystemName(""),
+	mGameName(""),
 	mGameIndex(-1)
 {
 	mWindow->setScreenSaver(this);
@@ -42,6 +42,11 @@ SystemScreenSaver::~SystemScreenSaver()
 bool SystemScreenSaver::allowSleep()
 {
 	return false;
+}
+
+bool SystemScreenSaver::isScreenSaverActive() 
+{
+	return (mState != STATE_INACTIVE);
 }
 
 void SystemScreenSaver::startScreenSaver()
@@ -114,7 +119,8 @@ void SystemScreenSaver::renderScreenSaver()
 	#ifdef _RPI_
 	// commenting out as we're defaulting to OMXPlayer for screensaver on the Pi
 	//if (Settings::getInstance()->getBool("VideoOmxPlayer"))
-	lOpacity = 1.0f;
+	if (Settings::getInstance()->getString("ScreenSaverBehavior") == "random video")
+		lOpacity = 1.0f;
 	#endif
 	if (mVideoScreensaver)
 	{
@@ -202,10 +208,13 @@ void SystemScreenSaver::pickRandomVideo(std::string& path)
 						{
 							// Yes. Resolve to a full path
 							path = resolvePath(videoNode.text().get(), (*it)->getStartPath(), true).generic_string();	
-							mSystemName = (*it)->getFullName().c_str();
+							mSystemName = (*it)->getFullName();
+							LOG(LogDebug) << "Setting System Name: " << mSystemName;
 							mGameName = fileNode.child("name").text().get();
+							LOG(LogDebug) << "Setting Game Name: " << mGameName;
 							mGameIndex = gameIndex;
-							writeSubtitle(mSystemName, mGameName);
+							LOG(LogDebug) << "Setting Game Index: " << mGameIndex;
+							writeSubtitle(mSystemName.c_str(), mGameName.c_str());
 							return;
 						}
 					}
@@ -257,20 +266,19 @@ void SystemScreenSaver::update(int deltaTime)
 		mVideoScreensaver->update(deltaTime);
 }
 
-const char* SystemScreenSaver::getSystemName()
+std::string SystemScreenSaver::getSystemName()
 {
-	if (mSystemName)
-		return mSystemName;
-	else
-		return "";
+	LOG(LogDebug) << "Getting System Name";
+	LOG(LogDebug) << "System Name: " << mSystemName;
+	return mSystemName;
 }
 
-const char* SystemScreenSaver::getGameName() 
+std::string SystemScreenSaver::getGameName() 
 {
-	if (mGameName)
-		return mGameName;
-	else
-		return "";
+
+	LOG(LogDebug) << "Getting Game Name";
+	LOG(LogDebug) << "Game Name: " << mGameName;
+	return mGameName;
 }
 
 int SystemScreenSaver::getGameIndex()

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "Window.h"
+
+class VideoComponent;
+
+// Screensaver implementation for main window
+class SystemScreenSaver : public Window::ScreenSaver
+{
+public:
+	SystemScreenSaver(Window* window);
+	virtual ~SystemScreenSaver();
+
+	virtual void startScreenSaver();
+	virtual void stopScreenSaver();
+	virtual void renderScreenSaver();
+	virtual bool allowSleep();
+	virtual void update(int deltaTime);
+
+private:
+	void	countVideos();
+	void	pickRandomVideo(std::string& path);
+
+	enum STATE {
+		STATE_INACTIVE,
+		STATE_FADE_OUT_WINDOW,
+		STATE_FADE_IN_VIDEO,
+		STATE_SCREENSAVER_ACTIVE
+	};
+
+private:
+	bool			mCounted;
+	unsigned long	mVideoCount;
+	VideoComponent* mVideoScreensaver;
+	Window*			mWindow;
+	STATE			mState;
+	float			mOpacity;
+	int				mTimer;
+};

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -20,6 +20,7 @@ public:
 private:
 	void	countVideos();
 	void	pickRandomVideo(std::string& path);
+    std::string	getTitlePath();
 
 	enum STATE {
 		STATE_INACTIVE,

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -16,16 +16,18 @@ public:
 	virtual void renderScreenSaver();
 	virtual bool allowSleep();
 	virtual void update(int deltaTime);
+	virtual bool isScreenSaverActive();
+
+// WIP
+
+    virtual std::string getSystemName();
+	virtual std::string getGameName();
+	virtual int getGameIndex();
 
 private:
 	void	countVideos();
 	void	pickRandomVideo(std::string& path);
 
-    // WIP
-
-    virtual const char* getSystemName();
-	virtual const char* getGameName();
-	virtual int getGameIndex();
 	void input(InputConfig* config, Input input);
 
 	enum STATE {
@@ -44,6 +46,6 @@ private:
 	float			mOpacity;
 	int				mTimer;
 	int   			mGameIndex;
-	const char*		mGameName;
-	const char*		mSystemName;	
+	std::string		mGameName;
+	std::string		mSystemName;	
 };

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -4,9 +4,6 @@
 
 class VideoComponent;
 
-std::string	getTitlePath();
-std::string	getTitleFolder();
-
 // Screensaver implementation for main window
 class SystemScreenSaver : public Window::ScreenSaver
 {
@@ -23,7 +20,6 @@ public:
 private:
 	void	countVideos();
 	void	pickRandomVideo(std::string& path);
-    void	writeSubtitle();
 
     // WIP
 

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -22,7 +22,14 @@ public:
 private:
 	void	countVideos();
 	void	pickRandomVideo(std::string& path);
-    void	writeSubtitle(const char* systemName, const char* gameName);
+    void	writeSubtitle();
+
+    // WIP
+
+    virtual const char* getSystemName();
+	virtual const char* getGameName();
+	virtual int getGameIndex();
+	void input(InputConfig* config, Input input);
 
 	enum STATE {
 		STATE_INACTIVE,
@@ -39,4 +46,7 @@ private:
 	STATE			mState;
 	float			mOpacity;
 	int				mTimer;
+	int   			mGameIndex;
+	const char*		mGameName;
+	const char*		mSystemName;	
 };

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -5,6 +5,7 @@
 class VideoComponent;
 
 std::string	getTitlePath();
+std::string	getTitleFolder();
 
 // Screensaver implementation for main window
 class SystemScreenSaver : public Window::ScreenSaver

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -22,7 +22,8 @@ public:
 
     virtual std::string getSystemName();
 	virtual std::string getGameName();
-	virtual int getGameIndex();
+	virtual FileData* getCurrentGame();
+	virtual void launchGame();
 
 private:
 	void	countVideos();
@@ -45,7 +46,7 @@ private:
 	STATE			mState;
 	float			mOpacity;
 	int				mTimer;
-	int   			mGameIndex;
+	FileData*		mCurrentGame;
 	std::string		mGameName;
 	std::string		mSystemName;	
 };

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -95,10 +95,11 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 			s->addSaveFunc([screensaver_time] { Settings::getInstance()->setInt("ScreenSaverTime", (int)round(screensaver_time->getValue()) * (1000 * 60)); });
 
 			// screensaver behavior
-			auto screensaver_behavior = std::make_shared< OptionListComponent<std::string> >(mWindow, "TRANSITION STYLE", false);
+			auto screensaver_behavior = std::make_shared< OptionListComponent<std::string> >(mWindow, "STYLE", false);
 			std::vector<std::string> screensavers;
 			screensavers.push_back("dim");
 			screensavers.push_back("black");
+			screensavers.push_back("random video");
 			for(auto it = screensavers.begin(); it != screensavers.end(); it++)
 				screensaver_behavior->add(*it, *it, Settings::getInstance()->getString("ScreenSaverBehavior") == *it);
 			s->addWithLabel("SCREENSAVER BEHAVIOR", screensaver_behavior);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -161,6 +161,26 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 				});
 			}
 
+			// Video Player - VideoOmxPlayer
+			auto omx_player = std::make_shared<SwitchComponent>(mWindow);
+			omx_player->setState(Settings::getInstance()->getBool("VideoOmxPlayer"));
+			s->addWithLabel("USE EXPERIMENTAL OMX VIDEO PLAYER", omx_player);
+			s->addSaveFunc([omx_player] { Settings::getInstance()->setBool("VideoOmxPlayer", omx_player->getState()); });
+
+			// Allow ScreenSaver Controls - ScreenSaverControls
+			auto ss_controls = std::make_shared<SwitchComponent>(mWindow);
+			ss_controls->setState(Settings::getInstance()->getBool("ScreenSaverControls"));
+			s->addWithLabel("SCREENSAVER CONTROLS", ss_controls);
+			s->addSaveFunc([ss_controls] { Settings::getInstance()->setBool("ScreenSaverControls", ss_controls->getState()); });
+
+
+			// Launch Game on Start from ScreenSaver - LaunchOnStart
+			auto launch_on_start = std::make_shared<SwitchComponent>(mWindow);
+			launch_on_start->setState(Settings::getInstance()->getBool("LaunchOnStart"));
+			s->addWithLabel("LAUNCH GAME FROM VIDEO SCREENSAVER", launch_on_start);
+			s->addSaveFunc([launch_on_start] { Settings::getInstance()->setBool("LaunchOnStart", launch_on_start->getState()); });
+
+
 			mWindow->pushGui(s);
 	});
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -165,7 +165,18 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 			auto omx_player = std::make_shared<SwitchComponent>(mWindow);
 			omx_player->setState(Settings::getInstance()->getBool("VideoOmxPlayer"));
 			s->addWithLabel("USE EXPERIMENTAL OMX VIDEO PLAYER", omx_player);
-			s->addSaveFunc([omx_player] { Settings::getInstance()->setBool("VideoOmxPlayer", omx_player->getState()); });
+			s->addSaveFunc([omx_player] 
+			{ 	
+				// need to reload all views to re-create the right video components
+				bool needReload = false;
+				if(Settings::getInstance()->getBool("VideoOmxPlayer") != omx_player->getState())
+					needReload = true;
+
+				Settings::getInstance()->setBool("VideoOmxPlayer", omx_player->getState());
+
+				if(needReload)
+					ViewController::get()->reloadAll();
+			});
 
 			// Allow ScreenSaver Controls - ScreenSaverControls
 			auto ss_controls = std::make_shared<SwitchComponent>(mWindow);
@@ -173,12 +184,17 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 			s->addWithLabel("SCREENSAVER CONTROLS", ss_controls);
 			s->addSaveFunc([ss_controls] { Settings::getInstance()->setBool("ScreenSaverControls", ss_controls->getState()); });
 
-
 			// Launch Game on Start from ScreenSaver - LaunchOnStart
 			auto launch_on_start = std::make_shared<SwitchComponent>(mWindow);
 			launch_on_start->setState(Settings::getInstance()->getBool("LaunchOnStart"));
 			s->addWithLabel("LAUNCH GAME FROM VIDEO SCREENSAVER", launch_on_start);
 			s->addSaveFunc([launch_on_start] { Settings::getInstance()->setBool("LaunchOnStart", launch_on_start->getState()); });
+
+			// Render Video Game Name as subtitles
+			auto ss_subtitles = std::make_shared<SwitchComponent>(mWindow);
+			ss_subtitles->setState(Settings::getInstance()->getBool("ScreenSaverGameName"));
+			s->addWithLabel("SHOW GAME AND SYSTEM NAME ON SCREENSAVER", ss_subtitles);
+			s->addSaveFunc([ss_subtitles] { Settings::getInstance()->setBool("ScreenSaverGameName", ss_subtitles->getState()); });
 
 
 			mWindow->pushGui(s);

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -14,6 +14,7 @@
 #include "platform.h"
 #include "Log.h"
 #include "Window.h"
+#include "SystemScreenSaver.h"
 #include "EmulationStation.h"
 #include "Settings.h"
 #include "ScraperCmdLine.h"
@@ -215,6 +216,7 @@ int main(int argc, char* argv[])
 	atexit(&onExit);
 
 	Window window;
+	SystemScreenSaver screensaver(&window);
 	ViewController::init(&window);
 	window.pushGui(ViewController::get());
 

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -92,6 +92,9 @@ void SystemView::goToSystem(SystemData* system, bool animate)
 
 bool SystemView::input(InputConfig* config, Input input)
 {
+	// pjft Debug
+	LOG(LogDebug) << "SystemView.cpp Input";
+
 	if(input.value != 0)
 	{
 		if(config->getDeviceId() == DEVICE_KEYBOARD && input.value && input.id == SDLK_r && SDL_GetModState() & KMOD_LCTRL && Settings::getInstance()->getBool("Debug"))
@@ -122,16 +125,15 @@ bool SystemView::input(InputConfig* config, Input input)
 			ViewController::get()->goToGameList(getSelected());
 			return true;
 		}
-		if(config->isMappedTo("select", input))
-		{			
-			LOG(LogDebug) << "Should be launching screensaver by virtue of Select";
-			//mWindow->startScreenSaver();
-			//mWindow->renderScreenSaver();
-			return false;
-		}
 	}else{
 		if(config->isMappedTo("left", input) || config->isMappedTo("right", input))
 			listInput(0);
+		if(config->isMappedTo("select", input))
+		{						
+			mWindow->startScreenSaver();
+			mWindow->renderScreenSaver();
+			return true;
+		}
 	}
 
 	return GuiComponent::input(config, input);

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -122,6 +122,13 @@ bool SystemView::input(InputConfig* config, Input input)
 			ViewController::get()->goToGameList(getSelected());
 			return true;
 		}
+		if(config->isMappedTo("select", input))
+		{			
+			LOG(LogDebug) << "Should be launching screensaver by virtue of Select";
+			mWindow->startScreenSaver();
+			//mWindow->renderScreenSaver();
+			return false;
+		}
 	}else{
 		if(config->isMappedTo("left", input) || config->isMappedTo("right", input))
 			listInput(0);

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -125,7 +125,7 @@ bool SystemView::input(InputConfig* config, Input input)
 		if(config->isMappedTo("select", input))
 		{			
 			LOG(LogDebug) << "Should be launching screensaver by virtue of Select";
-			mWindow->startScreenSaver();
+			//mWindow->startScreenSaver();
 			//mWindow->renderScreenSaver();
 			return false;
 		}

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -342,6 +342,8 @@ std::vector<HelpPrompt> SystemView::getHelpPrompts()
 	std::vector<HelpPrompt> prompts;
 	prompts.push_back(HelpPrompt("left/right", "choose"));
 	prompts.push_back(HelpPrompt("a", "select"));
+	if (Settings::getInstance()->getBool("ScreenSaverControls") && Settings::getInstance()->getString("ScreenSaverBehavior") == "random video")
+		prompts.push_back(HelpPrompt("select", "random game screensaver"));
 	return prompts;
 }
 

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -92,9 +92,6 @@ void SystemView::goToSystem(SystemData* system, bool animate)
 
 bool SystemView::input(InputConfig* config, Input input)
 {
-	// pjft Debug
-	LOG(LogDebug) << "SystemView.cpp Input";
-
 	if(input.value != 0)
 	{
 		if(config->getDeviceId() == DEVICE_KEYBOARD && input.value && input.id == SDLK_r && SDL_GetModState() & KMOD_LCTRL && Settings::getInstance()->getBool("Debug"))
@@ -128,7 +125,7 @@ bool SystemView::input(InputConfig* config, Input input)
 	}else{
 		if(config->isMappedTo("left", input) || config->isMappedTo("right", input))
 			listInput(0);
-		if(config->isMappedTo("select", input))
+		if(config->isMappedTo("select", input) && Settings::getInstance()->getBool("ScreenSaverControls"))
 		{						
 			mWindow->startScreenSaver();
 			mWindow->renderScreenSaver();

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -284,9 +284,6 @@ std::shared_ptr<SystemView> ViewController::getSystemListView()
 
 bool ViewController::input(InputConfig* config, Input input)
 {
-	// pjft Debug
-	LOG(LogDebug) << "ViewController.cpp Input";
-
 	if(mLockInput)
 		return true;
 

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -284,6 +284,9 @@ std::shared_ptr<SystemView> ViewController::getSystemListView()
 
 bool ViewController::input(InputConfig* config, Input input)
 {
+	// pjft Debug
+	LOG(LogDebug) << "ViewController.cpp Input";
+
 	if(mLockInput)
 		return true;
 

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -29,11 +29,11 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 	// Create the correct type of video window
 #ifdef _RPI_
 	if (Settings::getInstance()->getBool("VideoOmxPlayer"))
-		mVideo = new VideoPlayerComponent(window, false);
+		mVideo = new VideoPlayerComponent(window, NULL);
 	else
-		mVideo = new VideoVlcComponent(window);
+		mVideo = new VideoVlcComponent(window, NULL);
 #else
-	mVideo = new VideoVlcComponent(window);
+	mVideo = new VideoVlcComponent(window, NULL);
 #endif
 
 	mList.setPosition(mSize.x() * (0.50f + padding), mList.getPosition().y());

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #ifdef _RPI_
 #include "components/VideoPlayerComponent.h"
+#include "Settings.h"
 #endif
 #include "components/VideoVlcComponent.h"
 
@@ -27,7 +28,7 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 
 	// Create the correct type of video window
 #ifdef _RPI_
-	if (Settings::getBool("VideoOmxPlayer"))
+	if (Settings::getInstance()->getBool("VideoOmxPlayer"))
 		mVideo = new VideoPlayerComponent(window);
 	else
 		mVideo = new VideoVlcComponent(window);

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -29,11 +29,11 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 	// Create the correct type of video window
 #ifdef _RPI_
 	if (Settings::getInstance()->getBool("VideoOmxPlayer"))
-		mVideo = new VideoPlayerComponent(window, NULL);
+		mVideo = new VideoPlayerComponent(window, "");
 	else
-		mVideo = new VideoVlcComponent(window, NULL);
+		mVideo = new VideoVlcComponent(window, getTitlePath());
 #else
-	mVideo = new VideoVlcComponent(window, NULL);
+	mVideo = new VideoVlcComponent(window, getTitlePath());
 #endif
 
 	mList.setPosition(mSize.x() * (0.50f + padding), mList.getPosition().y());

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -4,13 +4,17 @@
 #include "animations/LambdaAnimation.h"
 #include <sys/stat.h>
 #include <fcntl.h>
+#ifdef _RPI_
+#include "components/VideoPlayerComponent.h"
+#endif
+#include "components/VideoVlcComponent.h"
 
 VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 	BasicGameListView(window, root), 
 	mDescContainer(window), mDescription(window), 
 	mMarquee(window),
 	mImage(window),
-	mVideo(window),
+	mVideo(nullptr),
 	mVideoPlaying(false),
 
 	mLblRating(window), mLblReleaseDate(window), mLblDeveloper(window), mLblPublisher(window), 
@@ -20,6 +24,16 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 	mGenre(window), mPlayers(window), mLastPlayed(window), mPlayCount(window)
 {
 	const float padding = 0.01f;
+
+	// Create the correct type of video window
+#ifdef _RPI_
+	if (Settings::getBool("VideoOmxPlayer"))
+		mVideo = new VideoPlayerComponent(window);
+	else
+		mVideo = new VideoVlcComponent(window);
+#else
+	mVideo = new VideoVlcComponent(window);
+#endif
 
 	mList.setPosition(mSize.x() * (0.50f + padding), mList.getPosition().y());
 	mList.setSize(mSize.x() * (0.50f - padding), mList.getSize().y());
@@ -40,17 +54,17 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 	addChild(&mImage);
 
 	// video
-	mVideo.setOrigin(0.5f, 0.5f);
-	mVideo.setPosition(mSize.x() * 0.25f, mSize.y() * 0.4f);
-	mVideo.setSize(mSize.x() * (0.5f - 2*padding), mSize.y() * 0.4f);
-	addChild(&mVideo);
+	mVideo->setOrigin(0.5f, 0.5f);
+	mVideo->setPosition(mSize.x() * 0.25f, mSize.y() * 0.4f);
+	mVideo->setSize(mSize.x() * (0.5f - 2*padding), mSize.y() * 0.4f);
+	addChild(mVideo);
 
 	// We want the video to be in front of the background but behind any 'extra' images
 	for (std::vector<GuiComponent*>::iterator it = mChildren.begin(); it != mChildren.end(); ++it)
 	{
 		if (*it == &mThemeExtras)
 		{
-			mChildren.insert(it, &mVideo);
+			mChildren.insert(it, mVideo);
 			mChildren.pop_back();
 			break;
 		}
@@ -99,6 +113,7 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 
 VideoGameListView::~VideoGameListView()
 {
+	delete mVideo;
 }
 
 void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
@@ -108,7 +123,7 @@ void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 	using namespace ThemeFlags;
 	mMarquee.applyTheme(theme, getName(), "md_marquee", POSITION | ThemeFlags::SIZE);
 	mImage.applyTheme(theme, getName(), "md_image", POSITION | ThemeFlags::SIZE);
-	mVideo.applyTheme(theme, getName(), "md_video", POSITION | ThemeFlags::SIZE | ThemeFlags::DELAY);
+	mVideo->applyTheme(theme, getName(), "md_video", POSITION | ThemeFlags::SIZE | ThemeFlags::DELAY);
 
 	initMDLabels();
 	std::vector<TextComponent*> labels = getMDLabels();
@@ -218,8 +233,8 @@ void VideoGameListView::updateInfoPanel()
 	bool fadingOut;
 	if(file == NULL)
 	{
-		mVideo.setVideo("");
-		mVideo.setImage("");
+		mVideo->setVideo("");
+		mVideo->setImage("");
 		mVideoPlaying = false;
 		//mMarquee.setImage("");
 		//mDescription.setText("");
@@ -248,11 +263,11 @@ void VideoGameListView::updateInfoPanel()
 			thumbnail_path.erase(0, 1);
 			thumbnail_path.insert(0, getHomePath());
 		}
-		if (!mVideo.setVideo(video_path))
-			mVideo.setDefaultVideo();
+		if (!mVideo->setVideo(video_path))
+			mVideo->setDefaultVideo();
 		mVideoPlaying = true;
 
-		mVideo.setImage(thumbnail_path);
+		mVideo->setImage(thumbnail_path);
 		mMarquee.setImage(marquee_path);
 		mImage.setImage(thumbnail_path);
 
@@ -276,7 +291,7 @@ void VideoGameListView::updateInfoPanel()
 
 	std::vector<GuiComponent*> comps = getMDValues();
 	comps.push_back(&mMarquee);
-	comps.push_back(&mVideo);
+	comps.push_back(mVideo);
 	comps.push_back(&mDescription);
 	comps.push_back(&mImage);
 	std::vector<TextComponent*> labels = getMDLabels();
@@ -305,7 +320,7 @@ void VideoGameListView::launch(FileData* game)
 {
 	Eigen::Vector3f target(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f, 0);
 	if(mMarquee.hasImage())
-		target << mVideo.getCenter().x(), mVideo.getCenter().y(), 0;
+		target << mVideo->getCenter().x(), mVideo->getCenter().y(), 0;
 
 	ViewController::get()->launch(game, target);
 }
@@ -341,5 +356,5 @@ std::vector<GuiComponent*> VideoGameListView::getMDValues()
 void VideoGameListView::update(int deltaTime)
 {
 	BasicGameListView::update(deltaTime);
-	mVideo.update(deltaTime);
+	mVideo->update(deltaTime);
 }

--- a/es-app/src/views/gamelist/VideoGameListView.h
+++ b/es-app/src/views/gamelist/VideoGameListView.h
@@ -5,6 +5,7 @@
 #include "components/RatingComponent.h"
 #include "components/DateTimeComponent.h"
 #include "components/VideoComponent.h"
+#include "components/VideoPlayerComponent.h"
 
 class VideoGameListView : public BasicGameListView
 {
@@ -28,7 +29,8 @@ private:
 	void initMDValues();
 
 	ImageComponent mMarquee;
-	VideoComponent mVideo;
+	//VideoComponent mVideo;
+	VideoPlayerComponent mVideo;
 	ImageComponent mImage;
 
 	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount;

--- a/es-app/src/views/gamelist/VideoGameListView.h
+++ b/es-app/src/views/gamelist/VideoGameListView.h
@@ -5,7 +5,6 @@
 #include "components/RatingComponent.h"
 #include "components/DateTimeComponent.h"
 #include "components/VideoComponent.h"
-#include "components/VideoPlayerComponent.h"
 
 class VideoGameListView : public BasicGameListView
 {
@@ -29,8 +28,7 @@ private:
 	void initMDValues();
 
 	ImageComponent mMarquee;
-	//VideoComponent mVideo;
-	VideoPlayerComponent mVideo;
+	VideoComponent* mVideo;
 	ImageComponent mImage;
 
 	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount;

--- a/es-core/CMakeLists.txt
+++ b/es-core/CMakeLists.txt
@@ -43,6 +43,7 @@ set(CORE_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/components/TextComponent.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/components/TextEditComponent.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/components/VideoComponent.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/components/VideoPlayerComponent.h
 
 	# Guis
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiDetectDevice.h
@@ -98,6 +99,7 @@ set(CORE_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/components/TextComponent.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/components/TextEditComponent.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/components/VideoComponent.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/components/VideoPlayerComponent.cpp
 
 	# Guis
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiDetectDevice.cpp

--- a/es-core/CMakeLists.txt
+++ b/es-core/CMakeLists.txt
@@ -44,6 +44,7 @@ set(CORE_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/components/TextEditComponent.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/components/VideoComponent.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/components/VideoPlayerComponent.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/components/VideoVlcComponent.h
 
 	# Guis
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiDetectDevice.h
@@ -100,6 +101,7 @@ set(CORE_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/components/TextEditComponent.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/components/VideoComponent.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/components/VideoPlayerComponent.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/components/VideoVlcComponent.cpp
 
 	# Guis
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiDetectDevice.cpp

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -369,3 +369,9 @@ void GuiComponent::onScreenSaverDeactivate()
 	for(unsigned int i = 0; i < getChildCount(); i++)		
 		getChild(i)->onScreenSaverDeactivate();		
 }
+
+void GuiComponent::topWindow(bool isTop)
+{
+	for(unsigned int i = 0; i < getChildCount(); i++)
+		getChild(i)->topWindow(isTop);
+}

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -358,4 +358,14 @@ void GuiComponent::onHide()
 		getChild(i)->onHide();
 }
 
-
+void GuiComponent::onScreenSaverActivate()		
+{		
+	for(unsigned int i = 0; i < getChildCount(); i++)		
+		getChild(i)->onScreenSaverActivate();		
+}		
+  		  
+void GuiComponent::onScreenSaverDeactivate()		
+{		
+	for(unsigned int i = 0; i < getChildCount(); i++)		
+		getChild(i)->onScreenSaverDeactivate();		
+}

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -28,6 +28,9 @@ GuiComponent::~GuiComponent()
 
 bool GuiComponent::input(InputConfig* config, Input input)
 {
+	// pjft Debug
+	LOG(LogDebug) << "GuiComponent.cpp Input";
+
 	for(unsigned int i = 0; i < getChildCount(); i++)
 	{
 		if(getChild(i)->input(config, input))

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -28,9 +28,6 @@ GuiComponent::~GuiComponent()
 
 bool GuiComponent::input(InputConfig* config, Input input)
 {
-	// pjft Debug
-	LOG(LogDebug) << "GuiComponent.cpp Input";
-
 	for(unsigned int i = 0; i < getChildCount(); i++)
 	{
 		if(getChild(i)->input(config, input))

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -82,6 +82,7 @@ public:
 	virtual void onHide();
 	virtual void onScreenSaverActivate();		
 	virtual void onScreenSaverDeactivate();
+	virtual void topWindow(bool isTop);
 	
 	// Default implementation just handles <pos> and <size> tags as normalized float pairs.
 	// You probably want to keep this behavior for any derived classes as well as add your own.

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -80,7 +80,9 @@ public:
 	
 	virtual void onShow();
 	virtual void onHide();
-
+	virtual void onScreenSaverActivate();		
+	virtual void onScreenSaverDeactivate();
+	
 	// Default implementation just handles <pos> and <size> tags as normalized float pairs.
 	// You probably want to keep this behavior for any derived classes as well as add your own.
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties);

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -170,6 +170,7 @@ InputConfig* InputManager::getInputConfigByDevice(int device)
 bool InputManager::parseEvent(const SDL_Event& ev, Window* window)
 {
 	bool causedEvent = false;
+	LOG(LogDebug) << "Event type received: " << ev.type;
 	switch(ev.type)
 	{
 	case SDL_JOYAXISMOTION:
@@ -193,7 +194,10 @@ bool InputManager::parseEvent(const SDL_Event& ev, Window* window)
 		return causedEvent;
 
 	case SDL_JOYBUTTONDOWN:
+		LOG(LogDebug) << "Event type Joy Button Down";
 	case SDL_JOYBUTTONUP:
+		if (ev.type == SDL_JOYBUTTONUP) 
+			LOG(LogDebug) << "Event type Joy Button Up";
 		window->input(getInputConfigByDevice(ev.jbutton.which), Input(ev.jbutton.which, TYPE_BUTTON, ev.jbutton.button, ev.jbutton.state == SDL_PRESSED, false));
 		return true;
 
@@ -202,6 +206,7 @@ bool InputManager::parseEvent(const SDL_Event& ev, Window* window)
 		return true;
 
 	case SDL_KEYDOWN:
+		LOG(LogDebug) << "Event type SDL Key Down";
 		if(ev.key.keysym.sym == SDLK_BACKSPACE && SDL_IsTextInputActive())
 		{
 			window->textInput("\b");
@@ -222,6 +227,7 @@ bool InputManager::parseEvent(const SDL_Event& ev, Window* window)
 		return true;
 
 	case SDL_KEYUP:
+		LOG(LogDebug) << "Event type SDL Key Up";
 		window->input(getInputConfigByDevice(DEVICE_KEYBOARD), Input(DEVICE_KEYBOARD, TYPE_KEY, ev.key.keysym.sym, 0, false));
 		return true;
 

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -77,11 +77,9 @@ void Settings::setDefaults()
 
 	// This setting only applies to raspberry pi but set it for all platforms so
 	// we don't get a warning if we encounter it on a different platform
-#ifdef _RPI_
-	mBoolMap["VideoOmxPlayer"] = true;
-#else
 	mBoolMap["VideoOmxPlayer"] = false;
-#endif
+	mBoolMap["LaunchOnStart"] = true;
+	mBoolMap["ScreenSaverControls"] = true;
 }
 
 template <typename K, typename V>

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -74,6 +74,14 @@ void Settings::setDefaults()
 	mStringMap["ThemeSet"] = "";
 	mStringMap["ScreenSaverBehavior"] = "dim";
 	mStringMap["Scraper"] = "TheGamesDB";
+
+	// This setting only applies to raspberry pi but set it for all platforms so
+	// we don't get a warning if we encounter it on a different platform
+#ifdef _RPI_
+	mBoolMap["VideoOmxPlayer"] = true;
+#else
+	mBoolMap["VideoOmxPlayer"] = false;
+#endif
 }
 
 template <typename K, typename V>

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -80,6 +80,7 @@ void Settings::setDefaults()
 	mBoolMap["VideoOmxPlayer"] = false;
 	mBoolMap["LaunchOnStart"] = true;
 	mBoolMap["ScreenSaverControls"] = true;
+	mBoolMap["ScreenSaverGameName"] = true;
 }
 
 template <typename K, typename V>

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -32,7 +32,7 @@ void Window::pushGui(GuiComponent* gui)
 	if (mGuiStack.size() > 0)
 	{
 		auto& top = mGuiStack.back();
-		top->onHide();
+		top->topWindow(false);
 	}
 	mGuiStack.push_back(gui);
 	gui->updateHelpPrompts();
@@ -49,7 +49,7 @@ void Window::removeGui(GuiComponent* gui)
 			if(i == mGuiStack.end() && mGuiStack.size()) // we just popped the stack and the stack is not empty
 			{
 				mGuiStack.back()->updateHelpPrompts();
-				mGuiStack.back()->onShow();
+				mGuiStack.back()->topWindow(true);
 			}
 
 			return;

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -116,6 +116,9 @@ void Window::textInput(const char* text)
 
 void Window::input(InputConfig* config, Input input)
 {
+	// pjft Debug
+	LOG(LogDebug) << "Window.cpp Input";
+	
 	if(mSleeping)
 	{
 		// wake up

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -117,8 +117,47 @@ void Window::textInput(const char* text)
 void Window::input(InputConfig* config, Input input)
 {
 	// pjft Debug
-	LOG(LogDebug) << "Window.cpp Input";
+	LOG(LogDebug) << "Window.cpp Input. Am I sleeping? " << (mSleeping ? "True" : "False");
+	if (mScreenSaver) {
+		LOG(LogDebug) << "Window.cpp Input. ScreenSaver active? " << (mScreenSaver->isScreenSaverActive() ? "True" : "False");
+		if(mScreenSaver->isScreenSaverActive()) 
+		{
+			if(mScreenSaver->getGameIndex() >= 0 && (config->isMappedTo("right", input) || config->isMappedTo("start", input))) 
+			{
+				if(config->isMappedTo("right", input)) 
+				{
+					LOG(LogDebug) << "Detected right input while video screensaver";
+					if (input.value != 0) {
+						LOG(LogDebug) << "Next video!";
+						// handle screensaver control, first stab
+						cancelScreenSaver();
+						startScreenSaver();
+					}
+					return;
+				}
+				else if(config->isMappedTo("start", input)) 
+				{
+					LOG(LogDebug) << "Detected Start while video screensaver";
+					// launch game!
+					LOG(LogDebug) << "Launch Game: " << mScreenSaver->getGameIndex();
+					//LOG(LogDebug) << "- System: " << mScreenSaver->getSystemName();
+
+					// get game info
+					
+
+					// wake up
+					mTimeSinceLastInput = 0;
+					cancelScreenSaver();
+					mSleeping = false;
+					onWake();
+				}
+			}
+		}
+	}
+		
 	
+
+
 	if(mSleeping)
 	{
 		// wake up

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -10,7 +10,7 @@
 #include "components/ImageComponent.h"
 
 Window::Window() : mNormalizeNextUpdate(false), mFrameTimeElapsed(0), mFrameCountElapsed(0), mAverageDeltaTime(10), 
-	mAllowSleep(true), mSleeping(false), mTimeSinceLastInput(0)
+	mAllowSleep(true), mSleeping(false), mTimeSinceLastInput(0), mScreenSaver(NULL), mRenderScreenSaver(false)
 {
 	mHelp = new HelpComponent(this);
 	mBackgroundOverlay = new ImageComponent(this);
@@ -120,12 +120,14 @@ void Window::input(InputConfig* config, Input input)
 	{
 		// wake up
 		mTimeSinceLastInput = 0;
+		cancelScreenSaver();
 		mSleeping = false;
 		onWake();
 		return;
 	}
 
 	mTimeSinceLastInput = 0;
+	cancelScreenSaver();
 
 	if(config->getDeviceId() == DEVICE_KEYBOARD && input.value && input.id == SDLK_g && SDL_GetModState() & KMOD_LCTRL && Settings::getInstance()->getBool("Debug"))
 	{
@@ -184,6 +186,10 @@ void Window::update(int deltaTime)
 
 	if(peekGui())
 		peekGui()->update(deltaTime);
+	
+	// Update the screensaver
+	if (mScreenSaver)
+		mScreenSaver->update(deltaTime);
 }
 
 void Window::render()
@@ -217,10 +223,15 @@ void Window::render()
 
 	unsigned int screensaverTime = (unsigned int)Settings::getInstance()->getInt("ScreenSaverTime");
 	if(mTimeSinceLastInput >= screensaverTime && screensaverTime != 0)
+		startScreenSaver();
+	
+	// Always call the screensaver render function regardless of whether the screensaver is active
+	// or not because it may perform a fade on transition
+	renderScreenSaver();
+	
+	if(mTimeSinceLastInput >= screensaverTime && screensaverTime != 0)
 	{
-		renderScreenSaver();
-
-		if (!isProcessing() && mAllowSleep)
+		if (!isProcessing() && mAllowSleep && (!mScreenSaver || mScreenSaver->allowSleep()))
 		{
 			// go to sleep
 			mSleeping = true;
@@ -357,9 +368,35 @@ bool Window::isProcessing()
 	return count_if(mGuiStack.begin(), mGuiStack.end(), [](GuiComponent* c) { return c->isProcessing(); }) > 0;
 }
 
-void Window::renderScreenSaver()
-{
-	Renderer::setMatrix(Eigen::Affine3f::Identity());
-	unsigned char opacity = Settings::getInstance()->getString("ScreenSaverBehavior") == "dim" ? 0xA0 : 0xFF;
-	Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), 0x00000000 | opacity);
-}
+void Window::startScreenSaver()		
+ {		
+ 	if (mScreenSaver && !mRenderScreenSaver)		
+ 	{		
+ 		// Tell the GUI components the screensaver is starting		
+ 		for(auto i = mGuiStack.begin(); i != mGuiStack.end(); i++)		
+ 			(*i)->onScreenSaverActivate();		
+ 		
+ 		mScreenSaver->startScreenSaver();		
+ 		mRenderScreenSaver = true;		
+ 	}		
+ }		
+ 		
+ void Window::cancelScreenSaver()		
+ {		
+ 	if (mScreenSaver && mRenderScreenSaver)		
+ 	{		
+ 		mScreenSaver->stopScreenSaver();		
+ 		mRenderScreenSaver = false;		
+ 		
+ 		// Tell the GUI components the screensaver has stopped		
+ 		for(auto i = mGuiStack.begin(); i != mGuiStack.end(); i++)		
+ 			(*i)->onScreenSaverDeactivate();		
+ 	}		
+ }		
+ 		
+ void Window::renderScreenSaver()		
+ {		
+ 	if (mScreenSaver)		
+ 		mScreenSaver->renderScreenSaver();		
+ }
+ 

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -122,7 +122,7 @@ void Window::input(InputConfig* config, Input input)
 		LOG(LogDebug) << "Window.cpp Input. ScreenSaver active? " << (mScreenSaver->isScreenSaverActive() ? "True" : "False");
 		if(mScreenSaver->isScreenSaverActive()) 
 		{
-			if(mScreenSaver->getGameIndex() >= 0 && (config->isMappedTo("right", input) || config->isMappedTo("start", input))) 
+			if(mScreenSaver->getCurrentGame() != NULL && (config->isMappedTo("right", input) || config->isMappedTo("start", input))) 
 			{
 				if(config->isMappedTo("right", input)) 
 				{
@@ -139,7 +139,7 @@ void Window::input(InputConfig* config, Input input)
 				{
 					LOG(LogDebug) << "Detected Start while video screensaver";
 					// launch game!
-					LOG(LogDebug) << "Launch Game: " << mScreenSaver->getGameIndex();
+					mScreenSaver->launchGame();
 					//LOG(LogDebug) << "- System: " << mScreenSaver->getSystemName();
 
 					// get game info

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -29,6 +29,11 @@ Window::~Window()
 
 void Window::pushGui(GuiComponent* gui)
 {
+	if (mGuiStack.size() > 0)
+	{
+		auto& top = mGuiStack.back();
+		top->onHide();
+	}
 	mGuiStack.push_back(gui);
 	gui->updateHelpPrompts();
 }
@@ -42,7 +47,10 @@ void Window::removeGui(GuiComponent* gui)
 			i = mGuiStack.erase(i);
 
 			if(i == mGuiStack.end() && mGuiStack.size()) // we just popped the stack and the stack is not empty
+			{
 				mGuiStack.back()->updateHelpPrompts();
+				mGuiStack.back()->onShow();
+			}
 
 			return;
 		}

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -116,20 +116,15 @@ void Window::textInput(const char* text)
 
 void Window::input(InputConfig* config, Input input)
 {
-	// pjft Debug
-	LOG(LogDebug) << "Window.cpp Input. Am I sleeping? " << (mSleeping ? "True" : "False");
 	if (mScreenSaver) {
-		LOG(LogDebug) << "Window.cpp Input. ScreenSaver active? " << (mScreenSaver->isScreenSaverActive() ? "True" : "False");
-		if(mScreenSaver->isScreenSaverActive()) 
+		if(mScreenSaver->isScreenSaverActive() && Settings::getInstance()->getBool("ScreenSaverControls")) 
 		{
-			if(mScreenSaver->getCurrentGame() != NULL && (config->isMappedTo("right", input) || config->isMappedTo("start", input))) 
+			if(mScreenSaver->getCurrentGame() != NULL && (config->isMappedTo("right", input) || config->isMappedTo("start", input) || config->isMappedTo("select", input))) 
 			{
-				if(config->isMappedTo("right", input)) 
+				if(config->isMappedTo("right", input) || config->isMappedTo("select", input)) 
 				{
-					LOG(LogDebug) << "Detected right input while video screensaver";
 					if (input.value != 0) {
-						LOG(LogDebug) << "Next video!";
-						// handle screensaver control, first stab
+						// handle screensaver control
 						cancelScreenSaver();
 						startScreenSaver();
 					}
@@ -137,26 +132,19 @@ void Window::input(InputConfig* config, Input input)
 				}
 				else if(config->isMappedTo("start", input)) 
 				{
-					LOG(LogDebug) << "Detected Start while video screensaver";
 					// launch game!
+					cancelScreenSaver();
 					mScreenSaver->launchGame();
-					//LOG(LogDebug) << "- System: " << mScreenSaver->getSystemName();
-
-					// get game info
-					
-
+				
 					// wake up
 					mTimeSinceLastInput = 0;
-					cancelScreenSaver();
 					mSleeping = false;
 					onWake();
+					return;
 				}
 			}
 		}
 	}
-		
-	
-
 
 	if(mSleeping)
 	{

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -18,6 +18,10 @@ public:
 		virtual void renderScreenSaver() = 0;		
 		virtual bool allowSleep() = 0;		
 		virtual void update(int deltaTime) = 0;		
+		virtual bool isScreenSaverActive() = 0;
+		virtual std::string getSystemName() = 0;
+		virtual std::string getGameName() = 0;
+		virtual int getGameIndex() = 0;
 	};
  
 	Window();

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -11,6 +11,15 @@ class ImageComponent;
 class Window
 {
 public:
+	class ScreenSaver {		
+	public:		
+		virtual void startScreenSaver() = 0;		
+		virtual void stopScreenSaver() = 0;		
+		virtual void renderScreenSaver() = 0;		
+		virtual bool allowSleep() = 0;		
+		virtual void update(int deltaTime) = 0;		
+	};
+ 
 	Window();
 	~Window();
 
@@ -36,6 +45,8 @@ public:
 
 	void renderHelpPromptsEarly(); // used to render HelpPrompts before a fade
 	void setHelpPrompts(const std::vector<HelpPrompt>& prompts, const HelpStyle& style);
+	
+	void setScreenSaver(ScreenSaver* screenSaver) { mScreenSaver = screenSaver; }
 
 private:
 	void onSleep();
@@ -44,9 +55,13 @@ private:
 	// Returns true if at least one component on the stack is processing
 	bool isProcessing();
 	void renderScreenSaver();
-
+	void startScreenSaver();
+	void cancelScreenSaver();
+ 
 	HelpComponent* mHelp;
 	ImageComponent* mBackgroundOverlay;
+	ScreenSaver*	mScreenSaver;
+	bool			mRenderScreenSaver;
 
 	std::vector<GuiComponent*> mGuiStack;
 

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -5,6 +5,7 @@
 #include "resources/Font.h"
 #include "InputManager.h"
 
+class FileData;
 class HelpComponent;
 class ImageComponent;
 
@@ -21,7 +22,8 @@ public:
 		virtual bool isScreenSaverActive() = 0;
 		virtual std::string getSystemName() = 0;
 		virtual std::string getGameName() = 0;
-		virtual int getGameIndex() = 0;
+		virtual FileData* getCurrentGame() = 0;
+		virtual void launchGame() = 0;
 	};
  
 	Window();

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -48,15 +48,19 @@ public:
 	
 	void setScreenSaver(ScreenSaver* screenSaver) { mScreenSaver = screenSaver; }
 
+	void startScreenSaver();
+	void cancelScreenSaver();
+	void renderScreenSaver();
+
 private:
 	void onSleep();
 	void onWake();
 
 	// Returns true if at least one component on the stack is processing
 	bool isProcessing();
-	void renderScreenSaver();
-	void startScreenSaver();
-	void cancelScreenSaver();
+	//void renderScreenSaver();
+	//void startScreenSaver();
+	//void cancelScreenSaver();
  
 	HelpComponent* mHelp;
 	ImageComponent* mBackgroundOverlay;

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -15,7 +15,9 @@ VideoComponent::VideoComponent(Window* window) :
 	mVideoWidth(0),
 	mStartDelayed(false),
 	mIsPlaying(false),
-	mShowing(false)
+	mShowing(false),
+	mScreensaverActive(false),
+	mDisable(false)
 {
 	// Setup the default configuration
 	mConfig.showSnapshotDelay 		= false;
@@ -256,8 +258,9 @@ void VideoComponent::update(int deltaTime)
 
 void VideoComponent::manageState()
 {
-	// We will only show if the component is on display
-	bool show = mShowing;
+	// We will only show if the component is on display and the screensaver
+	// is not active
+	bool show = mShowing && !mScreensaverActive && !mDisable;
 
 	// See if we're already playing
 	if (mIsPlaying)
@@ -300,4 +303,20 @@ void VideoComponent::onHide()
 	manageState();
 }
 
+void VideoComponent::onScreenSaverActivate()
+{
+	mScreensaverActive = true;
+	manageState();
+}
 
+void VideoComponent::onScreenSaverDeactivate()
+{
+	mScreensaverActive = false;
+	manageState();
+}
+
+void VideoComponent::topWindow(bool isTop)
+{
+	mDisable = !isTop;
+	manageState();
+}

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -8,51 +8,19 @@
 
 #define FADE_TIME_MS	200
 
-libvlc_instance_t*		VideoComponent::mVLC = NULL;
-
-// VLC prepares to render a video frame.
-static void *lock(void *data, void **p_pixels) {
-    struct VideoContext *c = (struct VideoContext *)data;
-    SDL_LockMutex(c->mutex);
-    SDL_LockSurface(c->surface);
-	*p_pixels = c->surface->pixels;
-    return NULL; // Picture identifier, not needed here.
-}
-
-// VLC just rendered a video frame.
-static void unlock(void *data, void *id, void *const *p_pixels) {
-    struct VideoContext *c = (struct VideoContext *)data;
-    SDL_UnlockSurface(c->surface);
-    SDL_UnlockMutex(c->mutex);
-}
-
-// VLC wants to display a video frame.
-static void display(void *data, void *id) {
-    //Data to be displayed
-}
-
 VideoComponent::VideoComponent(Window* window) :
 	GuiComponent(window),
 	mStaticImage(window),
-	mMediaPlayer(nullptr),
 	mVideoHeight(0),
 	mVideoWidth(0),
 	mStartDelayed(false),
 	mIsPlaying(false),
 	mShowing(false)
 {
-	memset(&mContext, 0, sizeof(mContext));
-
 	// Setup the default configuration
 	mConfig.showSnapshotDelay 		= false;
 	mConfig.showSnapshotNoVideo		= false;
 	mConfig.startDelay				= 0;
-
-	// Get an empty texture for rendering the video
-	mTexture = TextureResource::get("");
-
-	// Make sure VLC has been initialised
-	setupVLC();
 }
 
 VideoComponent::~VideoComponent()
@@ -83,7 +51,7 @@ void VideoComponent::onSizeChanged()
 
 bool VideoComponent::setVideo(std::string path)
 {
-	// Convert the path into a format VLC can understand
+	// Convert the path into a generic format
 	boost::filesystem::path fullPath = getCanonicalPath(path);
 	fullPath.make_preferred().native();
 
@@ -137,83 +105,14 @@ void VideoComponent::render(const Eigen::Affine3f& parentTrans)
 	GuiComponent::renderChildren(trans);
 
 	Renderer::setMatrix(trans);
-	
+
 	// Handle the case where the video is delayed
 	handleStartDelay();
 
 	// Handle looping of the video
 	handleLooping();
 
-	if (mIsPlaying && mContext.valid)
-	{
-		float tex_offs_x = 0.0f;
-		float tex_offs_y = 0.0f;
-		float x2;
-		float y2;
-
-		x = -(float)mSize.x() * mOrigin.x();
-		y = -(float)mSize.y() * mOrigin.y();
-		x2 = x+mSize.x();
-		y2 = y+mSize.y();
-
-		// Define a structure to contain the data for each vertex
-		struct Vertex
-		{
-			Eigen::Vector2f pos;
-			Eigen::Vector2f tex;
-			Eigen::Vector4f colour;
-		} vertices[6];
-
-		// We need two triangles to cover the rectangular area
-		vertices[0].pos[0] = x; 			vertices[0].pos[1] = y;
-		vertices[1].pos[0] = x; 			vertices[1].pos[1] = y2;
-		vertices[2].pos[0] = x2;			vertices[2].pos[1] = y;
-
-		vertices[3].pos[0] = x2;			vertices[3].pos[1] = y;
-		vertices[4].pos[0] = x; 			vertices[4].pos[1] = y2;
-		vertices[5].pos[0] = x2;			vertices[5].pos[1] = y2;
-
-		// Texture coordinates
-		vertices[0].tex[0] = -tex_offs_x; 			vertices[0].tex[1] = -tex_offs_y;
-		vertices[1].tex[0] = -tex_offs_x; 			vertices[1].tex[1] = 1.0f + tex_offs_y;
-		vertices[2].tex[0] = 1.0f + tex_offs_x;		vertices[2].tex[1] = -tex_offs_y;
-
-		vertices[3].tex[0] = 1.0f + tex_offs_x;		vertices[3].tex[1] = -tex_offs_y;
-		vertices[4].tex[0] = -tex_offs_x;			vertices[4].tex[1] = 1.0f + tex_offs_y;
-		vertices[5].tex[0] = 1.0f + tex_offs_x;		vertices[5].tex[1] = 1.0f + tex_offs_y;
-
-		// Colours - use this to fade the video in and out
-		for (int i = 0; i < (4 * 6); ++i) {
-			if ((i%4) < 3)
-				vertices[i / 4].colour[i % 4] = mFadeIn;
-			else
-				vertices[i / 4].colour[i % 4] = 1.0f;
-		}
-
-		glEnable(GL_TEXTURE_2D);
-
-		// Build a texture for the video frame
-		mTexture->initFromPixels((unsigned char*)mContext.surface->pixels, mContext.surface->w, mContext.surface->h);
-		mTexture->bind();
-
-		// Render it
-		glEnableClientState(GL_COLOR_ARRAY);
-		glEnableClientState(GL_VERTEX_ARRAY);
-		glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-
-		glColorPointer(4, GL_FLOAT, sizeof(Vertex), &vertices[0].colour);
-		glVertexPointer(2, GL_FLOAT, sizeof(Vertex), &vertices[0].pos);
-		glTexCoordPointer(2, GL_FLOAT, sizeof(Vertex), &vertices[0].tex);
-
-		glDrawArrays(GL_TRIANGLES, 0, 6);
-
-		glDisableClientState(GL_VERTEX_ARRAY);
-		glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-		glDisableClientState(GL_COLOR_ARRAY);
-
-		glDisable(GL_TEXTURE_2D);
-	}
-	else
+	if (!mIsPlaying)
 	{
 		// This is the case where the video is not currently being displayed. Work out
 		// if we need to display a static image
@@ -279,37 +178,6 @@ std::vector<HelpPrompt> VideoComponent::getHelpPrompts()
 	return ret;
 }
 
-void VideoComponent::setupContext()
-{
-	if (!mContext.valid)
-	{
-		// Create an RGBA surface to render the video into
-		mContext.surface = SDL_CreateRGBSurface(SDL_SWSURFACE, (int)mVideoWidth, (int)mVideoHeight, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
-		mContext.mutex = SDL_CreateMutex();
-		mContext.valid = true;
-	}
-}
-
-void VideoComponent::freeContext()
-{
-	if (mContext.valid)
-	{
-		SDL_FreeSurface(mContext.surface);
-		SDL_DestroyMutex(mContext.mutex);
-		mContext.valid = false;
-	}
-}
-
-void VideoComponent::setupVLC()
-{
-	// If VLC hasn't been initialised yet then do it now
-	if (!mVLC)
-	{
-		const char* args[] = { "--quiet" };
-		mVLC = libvlc_new(sizeof(args) / sizeof(args[0]), args);
-	}
-}
-
 void VideoComponent::handleStartDelay()
 {
 	// Only play if any delay has timed out
@@ -330,74 +198,6 @@ void VideoComponent::handleStartDelay()
 
 void VideoComponent::handleLooping()
 {
-	if (mIsPlaying && mMediaPlayer)
-	{
-		libvlc_state_t state = libvlc_media_player_get_state(mMediaPlayer);
-		if (state == libvlc_Ended)
-		{
-			//libvlc_media_player_set_position(mMediaPlayer, 0.0f);
-			libvlc_media_player_set_media(mMediaPlayer, mMedia);
-			libvlc_media_player_play(mMediaPlayer);
-		}
-	}
-}
-
-void VideoComponent::startVideo()
-{
-	if (!mIsPlaying) {
-		mVideoWidth = 0;
-		mVideoHeight = 0;
-
-#ifdef WIN32
-		std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> wton;
-		std::string path = wton.to_bytes(mVideoPath.c_str());
-#else
-		std::string path(mVideoPath.c_str());
-#endif
-		// Make sure we have a video path
-		if (mVLC && (path.size() > 0))
-		{
-			// Set the video that we are going to be playing so we don't attempt to restart it
-			mPlayingVideoPath = mVideoPath;
-
-			// Open the media
-			mMedia = libvlc_media_new_path(mVLC, path.c_str());
-			if (mMedia)
-			{
-				unsigned 	track_count;
-				// Get the media metadata so we can find the aspect ratio
-				libvlc_media_parse(mMedia);
-				libvlc_media_track_t** tracks;
-				track_count = libvlc_media_tracks_get(mMedia, &tracks);
-				for (unsigned track = 0; track < track_count; ++track)
-				{
-					if (tracks[track]->i_type == libvlc_track_video)
-					{
-						mVideoWidth = tracks[track]->video->i_width;
-						mVideoHeight = tracks[track]->video->i_height;
-						break;
-					}
-				}
-				libvlc_media_tracks_release(tracks, track_count);
-
-				// Make sure we found a valid video track
-				if ((mVideoWidth > 0) && (mVideoHeight > 0))
-				{
-					setupContext();
-
-					// Setup the media player
-					mMediaPlayer = libvlc_media_player_new_from_media(mMedia);
-					libvlc_media_player_play(mMediaPlayer);
-					libvlc_video_set_callbacks(mMediaPlayer, lock, unlock, display, (void*)&mContext);
-					libvlc_video_set_format(mMediaPlayer, "RGBA", (int)mVideoWidth, (int)mVideoHeight, (int)mVideoWidth * 4);
-
-					// Update the playing state
-					mIsPlaying = true;
-					mFadeIn = 0.0f;
-				}
-			}
-		}
-	}
 }
 
 void VideoComponent::startVideoWithDelay()
@@ -422,21 +222,6 @@ void VideoComponent::startVideoWithDelay()
 			mStartTime = SDL_GetTicks() + mConfig.startDelay;
 		}
 		mIsPlaying = true;
-	}
-}
-
-void VideoComponent::stopVideo()
-{
-	mIsPlaying = false;
-	mStartDelayed = false;
-	// Release the media player so it stops calling back to us
-	if (mMediaPlayer)
-	{
-		libvlc_media_player_stop(mMediaPlayer);
-		libvlc_media_player_release(mMediaPlayer);
-		libvlc_media_release(mMedia);
-		mMediaPlayer = NULL;
-		freeContext();
 	}
 }
 

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -8,6 +8,35 @@
 
 #define FADE_TIME_MS	200
 
+std::string getTitlePath() {
+	std::string titleFolder = getTitleFolder();
+	return titleFolder + "last_title.srt";
+}
+
+std::string getTitleFolder() {
+	std::string home = getHomePath();
+	return home + "/.emulationstation/tmp/";
+}
+
+void writeSubtitle(const char* gameName, const char* systemName) 
+{
+	FILE* file = fopen(getTitlePath().c_str(), "w");	
+	fprintf(file, "1\n00:00:01,000 --> 00:00:08,000\n");
+	fprintf(file, "%s\n", gameName);
+	fprintf(file, "<i>%s</i>\n\n", systemName);
+	fprintf(file, "2\n00:00:29,000 --> 00:00:35,000\n");
+	fprintf(file, "%s\n", gameName);
+	fprintf(file, "<i>%s</i>\n", systemName);
+	fflush(file);
+	fclose(file);
+	file = NULL;
+}
+
+void VideoComponent::setScreensaverMode(bool isScreensaver)
+{
+	mScreensaverMode = isScreensaver;
+}
+
 VideoComponent::VideoComponent(Window* window) :
 	GuiComponent(window),
 	mStaticImage(window),
@@ -17,18 +46,25 @@ VideoComponent::VideoComponent(Window* window) :
 	mIsPlaying(false),
 	mShowing(false),
 	mScreensaverActive(false),
-	mDisable(false)
+	mDisable(false),
+	mScreensaverMode(false)
 {
 	// Setup the default configuration
 	mConfig.showSnapshotDelay 		= false;
 	mConfig.showSnapshotNoVideo		= false;
 	mConfig.startDelay				= 0;
+
+	std::string path = getTitleFolder();
+	if(!boost::filesystem::exists(path))
+		boost::filesystem::create_directory(path);
 }
 
 VideoComponent::~VideoComponent()
 {
 	// Stop any currently running video
 	stopVideo();
+	// Delete subtitle file, if existing
+	remove(getTitlePath().c_str());
 }
 
 void VideoComponent::setOrigin(float originX, float originY)

--- a/es-core/src/components/VideoComponent.h
+++ b/es-core/src/components/VideoComponent.h
@@ -37,6 +37,9 @@ public:
 	
 	virtual void onShow() override;
 	virtual void onHide() override;
+	virtual void onScreenSaverActivate() override;
+	virtual void onScreenSaverDeactivate() override;
+	virtual void topWindow(bool isTop) override;
 
 	//Sets the origin as a percentage of this image (e.g. (0, 0) is top left, (0.5, 0.5) is the center)
 	void setOrigin(float originX, float originY);
@@ -87,6 +90,8 @@ protected:
 	unsigned						mStartTime;
 	bool							mIsPlaying;
 	bool							mShowing;
+	bool							mDisable;
+	bool							mScreensaverActive;
 
 	Configuration					mConfig;
 };

--- a/es-core/src/components/VideoComponent.h
+++ b/es-core/src/components/VideoComponent.h
@@ -12,6 +12,10 @@
 #include <SDL_mutex.h>
 #include <boost/filesystem.hpp>
 
+std::string	getTitlePath();
+std::string	getTitleFolder();
+void writeSubtitle(const char* gameName, const char* systemName);
+
 class VideoComponent : public GuiComponent
 {
 	// Structure that groups together the configuration of the video component
@@ -34,6 +38,9 @@ public:
 
 	// Configures the component to show the default video
 	void setDefaultVideo();
+
+	// sets whether it's going to render in screensaver mode
+	void setScreensaverMode(bool isScreensaver);
 	
 	virtual void onShow() override;
 	virtual void onHide() override;
@@ -92,7 +99,7 @@ protected:
 	bool							mShowing;
 	bool							mDisable;
 	bool							mScreensaverActive;
-
+	bool							mScreensaverMode;
 	Configuration					mConfig;
 };
 

--- a/es-core/src/components/VideoComponent.h
+++ b/es-core/src/components/VideoComponent.h
@@ -8,17 +8,9 @@
 #include "ImageComponent.h"
 #include <string>
 #include <memory>
-#include "resources/TextureResource.h"
-#include <vlc/vlc.h>
 #include <SDL.h>
 #include <SDL_mutex.h>
 #include <boost/filesystem.hpp>
-
-struct VideoContext {
-	SDL_Surface*		surface;
-	SDL_mutex*			mutex;
-	bool				valid;
-};
 
 class VideoComponent : public GuiComponent
 {
@@ -32,8 +24,6 @@ class VideoComponent : public GuiComponent
 	};
 
 public:
-	static void setupVLC();
-
 	VideoComponent(Window* window);
 	virtual ~VideoComponent();
 
@@ -55,8 +45,6 @@ public:
 	void onSizeChanged() override;
 	void setOpacity(unsigned char opacity) override;
 
-	void render(const Eigen::Affine3f& parentTrans) override;
-
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
@@ -66,35 +54,29 @@ public:
 
 	virtual void update(int deltaTime);
 
-private:
+	void render(const Eigen::Affine3f& parentTrans) override;
+
+protected:
 	// Start the video Immediately
-	void startVideo();
+	virtual void startVideo() = 0;
+	// Stop the video
+	virtual void stopVideo() { };
+	// Handle looping the video. Must be called periodically
+	virtual void handleLooping();
+
 	// Start the video after any configured delay
 	void startVideoWithDelay();
-	// Stop the video
-	void stopVideo();
-
-	void setupContext();
-	void freeContext();
 
 	// Handle any delay to the start of playing the video clip. Must be called periodically
 	void handleStartDelay();
 
-	// Handle looping the video. Must be called periodically
-	void handleLooping();
-
 	// Manage the playing state of the component
 	void manageState();
 
-private:
-	static libvlc_instance_t*		mVLC;
-	libvlc_media_t*					mMedia;
-	libvlc_media_player_t*			mMediaPlayer;
-	VideoContext					mContext;
+protected:
 	unsigned						mVideoWidth;
 	unsigned						mVideoHeight;
 	Eigen::Vector2f 				mOrigin;
-	std::shared_ptr<TextureResource> mTexture;
 	float							mFadeIn;
 	std::string						mStaticImagePath;
 	ImageComponent					mStaticImage;

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -2,6 +2,7 @@
 #include "components/VideoPlayerComponent.h"
 #include "Renderer.h"
 #include "ThemeData.h"
+#include "Settings.h"
 #include "Util.h"
 #include <signal.h>
 #include <wait.h>

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -8,12 +8,15 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include "Log.h"
 
-VideoPlayerComponent::VideoPlayerComponent(Window* window, const char* subtitleFolder) :
+VideoPlayerComponent::VideoPlayerComponent(Window* window, std::string subtitlePath) :
 	VideoComponent(window),
 	mPlayerPid(-1),
-	subtitles(subtitleFolder)
+	subtitles(subtitlePath)
 {
+	LOG(LogDebug) << "Initializing Player with Subtitles at: " <<  subtitlePath;
+	LOG(LogDebug) << " - Local var: " << subtitles;
 }
 
 VideoPlayerComponent::~VideoPlayerComponent()
@@ -65,28 +68,21 @@ void VideoPlayerComponent::startVideo()
 				sprintf(buf, "%d,%d,%d,%d", (int)x, (int)y, (int)(x + mSize.x()), (int)(y + mSize.y()));
 				// We need to specify the layer of 10000 or above to ensure the video is displayed on top
 				// of our SDL display
-				const char* argv[] = { "", "--layer", "10010", "--loop", "--no-osd", "--aspect-mode", "letterbox", "--win", buf, "-b", "", "", "", "", "","", NULL };
+				const char* argv[] = { "", "--layer", "10010", "--loop", "--no-osd", "--aspect-mode", "letterbox", "--win", buf, "-b", "", NULL };
 				
-				if (subtitles) 
+				LOG(LogDebug) << "Subtitles: " << subtitles;
+
+				if (!subtitles.empty()) 
 				{	
+					LOG(LogDebug) << "We have Subs! Setting subtitles: " << subtitles;
 					argv[7] = "--subtitles";
-					argv[8] = subtitles;
-					argv[9] = mPlayingVideoPath.c_str();
-					/*argv[10] = "--no-ghost-box";
-					argv[11] = "--align"; 
-					argv[12] = "center";*/
-					argv[15] = "";
-					
-				} 
-				else 
-				{
-					argv[9] = mPlayingVideoPath.c_str();
-				}
+					argv[8] = subtitles.c_str();
+				} 				
 				
 				//const char* argv[] = args;
 				const char* env[] = { "LD_LIBRARY_PATH=/opt/vc/libs:/usr/lib/omxplayer", NULL };
 				// Fill in the empty argument with the video path
-				//argv[10] = mPlayingVideoPath.c_str();
+				argv[9] = mPlayingVideoPath.c_str();
 				
 				// Redirect stdout
 				int fdin = open("/dev/null", O_RDONLY);

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -196,14 +196,20 @@ void VideoPlayerComponent::startVideo()
 				mPlayingVideoPath = "";
 			}
 			else if (pid > 0)
+			{
 				mPlayerPid = pid;
+			}
 			else
 			{
-				printf("Child\n");
-				const char* argv[] = { "", "-noborder", "-ao", "null", "-vo", "xv", "-display", ":0", "-geometry", "320x200+700+500", "/home/roy/tmp/MameVideosMkv/720.mkv", NULL };
-				const char* env[] = { NULL };
-				argv[10] = mPlayingVideoPath.c_str();
-				execve("/usr/bin/mplayer", (char**)argv, (char**)env);
+				char buf[512];
+				sprintf(buf, "%d,%d,%d,%d", (int)mPosition.x(), (int)mPosition.y(), (int)(mPosition.x() + mSize.x()), (int)(mPosition.y() + mSize.y()));
+
+				const char* argv[] = { "", "--win", buf, "--layer", "10000", "--loop", "--no-osd", "", NULL };
+				//const char* argv[] = { "", "-noborder", "-ao", "null", "-vo", "xv", "-display", ":0", "-geometry", "320x200+700+500", "/home/roy/tmp/MameVideosMkv/720.mkv", NULL };
+				const char* env[] = { "LD_LIBRARY_PATH=/opt/vc/libs:/usr/lib/omxplayer", NULL };
+				argv[7] = mPlayingVideoPath.c_str();
+				execve("/usr/bin/omxplayer.bin", (char**)argv, (char**)env);
+				//execve("/usr/bin/mplayer", (char**)argv, (char**)env);
 				_exit(EXIT_FAILURE);
 			}
 		}
@@ -299,7 +305,5 @@ void VideoPlayerComponent::onShow()
 void VideoPlayerComponent::onHide()
 {
 	mShowing = false;
-	manageState();
 }
-
 

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -63,10 +63,10 @@ void VideoPlayerComponent::startVideo()
 				sprintf(buf, "%d,%d,%d,%d", (int)x, (int)y, (int)(x + mSize.x()), (int)(y + mSize.y()));
 				// We need to specify the layer of 10000 or above to ensure the video is displayed on top
 				// of our SDL display
-				const char* argv[] = { "", "--win", buf, "--layer", "10000", "--loop", "--no-osd", "", NULL };
+				const char* argv[] = { "", "--win", buf, "--layer", "10000", "--loop", "--no-osd", "-b", "--aspect-mode", "letterbox","", NULL };
 				const char* env[] = { "LD_LIBRARY_PATH=/opt/vc/libs:/usr/lib/omxplayer", NULL };
 				// Fill in the empty argument with the video path
-				argv[7] = mPlayingVideoPath.c_str();
+				argv[10] = mPlayingVideoPath.c_str();
 				// Redirect stdout
 				int fdin = open("/dev/null", O_RDONLY);
 				int fdout = open("/dev/null", O_WRONLY);

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -201,8 +201,10 @@ void VideoPlayerComponent::startVideo()
 			}
 			else
 			{
+				float x = mPosition.x() - (mOrigin.x() * mSize.x());
+				float y = mPosition.y() - (mOrigin.y() * mSize.y());
 				char buf[512];
-				sprintf(buf, "%d,%d,%d,%d", (int)mPosition.x(), (int)mPosition.y(), (int)(mPosition.x() + mSize.x()), (int)(mPosition.y() + mSize.y()));
+				sprintf(buf, "%d,%d,%d,%d", (int)x, (int)y, (int)(x + mSize.x()), (int)(y + mSize.y()));
 
 				const char* argv[] = { "", "--win", buf, "--layer", "10000", "--loop", "--no-osd", "", NULL };
 				//const char* argv[] = { "", "-noborder", "-ao", "null", "-vo", "xv", "-display", ":0", "-geometry", "320x200+700+500", "/home/roy/tmp/MameVideosMkv/720.mkv", NULL };
@@ -305,5 +307,6 @@ void VideoPlayerComponent::onShow()
 void VideoPlayerComponent::onHide()
 {
 	mShowing = false;
+	manageState();
 }
 

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -85,7 +85,7 @@ void VideoPlayerComponent::startVideo()
 				} 
 				else 
 				{
-					argv[10] = mPlayingVideoPath.c_str();
+					argv[9] = mPlayingVideoPath.c_str();
 				}
 				
 				//const char* argv[] = args;

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -1,0 +1,305 @@
+#include "components/VideoPlayerComponent.h"
+#include "Renderer.h"
+#include "ThemeData.h"
+#include "Util.h"
+#include <signal.h>
+#include <wait.h>
+#ifdef WIN32
+#include <codecvt>
+#endif
+
+VideoPlayerComponent::VideoPlayerComponent(Window* window) :
+	GuiComponent(window),
+	mStaticImage(window),
+	mVideoHeight(0),
+	mVideoWidth(0),
+	mStartDelayed(false),
+	mIsPlaying(false),
+	mShowing(false),
+	mPlayerPid(-1)
+{
+	// Setup the default configuration
+	mConfig.showSnapshotDelay 		= false;
+	mConfig.showSnapshotNoVideo		= false;
+	mConfig.startDelay				= 0;
+}
+
+VideoPlayerComponent::~VideoPlayerComponent()
+{
+	// Stop any currently running video
+	stopVideo();
+}
+
+void VideoPlayerComponent::setOrigin(float originX, float originY)
+{
+	mOrigin << originX, originY;
+
+	// Update the embeded static image
+	mStaticImage.setOrigin(originX, originY);
+}
+
+Eigen::Vector2f VideoPlayerComponent::getCenter() const
+{
+	return Eigen::Vector2f(mPosition.x() - (getSize().x() * mOrigin.x()) + getSize().x() / 2,
+		mPosition.y() - (getSize().y() * mOrigin.y()) + getSize().y() / 2);
+}
+
+void VideoPlayerComponent::onSizeChanged()
+{
+	// Update the embeded static image
+	mStaticImage.onSizeChanged();
+}
+
+bool VideoPlayerComponent::setVideo(std::string path)
+{
+	// Get the full native path
+	boost::filesystem::path fullPath = getCanonicalPath(path);
+	fullPath.make_preferred().native();
+
+	// Check that it's changed
+	if (fullPath == mVideoPath)
+		return !path.empty();
+
+	// Store the path
+	mVideoPath = fullPath;
+
+	// If the file exists then set the new video
+	if (!fullPath.empty() && ResourceManager::getInstance()->fileExists(fullPath.generic_string()))
+	{
+		// Return true to show that we are going to attempt to play a video
+		return true;
+	}
+	// Return false to show that no video will be displayed
+	return false;
+}
+
+void VideoPlayerComponent::setImage(std::string path)
+{
+	// Check that the image has changed
+	if (path == mStaticImagePath)
+		return;
+	
+	mStaticImage.setImage(path);
+	// Make the image stretch to fill the video region
+	mStaticImage.setSize(getSize());
+	mStaticImagePath = path;
+}
+
+void VideoPlayerComponent::setDefaultVideo()
+{
+	setVideo(mConfig.defaultVideoPath);
+}
+
+void VideoPlayerComponent::setOpacity(unsigned char opacity)
+{
+	// Update the embeded static image
+	mStaticImage.setOpacity(opacity);
+}
+
+void VideoPlayerComponent::render(const Eigen::Affine3f& parentTrans)
+{
+}
+
+void VideoPlayerComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties)
+{
+	using namespace ThemeFlags;
+
+	const ThemeData::ThemeElement* elem = theme->getElement(view, element, "video");
+	if(!elem)
+	{
+		return;
+	}
+
+	Eigen::Vector2f scale = getParent() ? getParent()->getSize() : Eigen::Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
+
+	if ((properties & POSITION) && elem->has("pos"))
+	{
+		Eigen::Vector2f denormalized = elem->get<Eigen::Vector2f>("pos").cwiseProduct(scale);
+		setPosition(Eigen::Vector3f(denormalized.x(), denormalized.y(), 0));
+	}
+
+	if ((properties & ThemeFlags::SIZE) && elem->has("size"))
+	{
+		setSize(elem->get<Eigen::Vector2f>("size").cwiseProduct(scale));
+	}
+
+	// position + size also implies origin
+	if (((properties & ORIGIN) || ((properties & POSITION) && (properties & ThemeFlags::SIZE))) && elem->has("origin"))
+		setOrigin(elem->get<Eigen::Vector2f>("origin"));
+
+	if(elem->has("default"))
+		mConfig.defaultVideoPath = elem->get<std::string>("default");
+
+	if((properties & ThemeFlags::DELAY) && elem->has("delay"))
+		mConfig.startDelay = (unsigned)(elem->get<float>("delay") * 1000.0f);
+
+	if (elem->has("showSnapshotNoVideo"))
+		mConfig.showSnapshotNoVideo = elem->get<bool>("showSnapshotNoVideo");
+
+	if (elem->has("showSnapshotDelay"))
+		mConfig.showSnapshotDelay = elem->get<bool>("showSnapshotDelay");
+
+	// Update the embeded static image
+	mStaticImage.setPosition(getPosition());
+	mStaticImage.setMaxSize(getSize());
+	mStaticImage.setSize(getSize());
+}
+
+std::vector<HelpPrompt> VideoPlayerComponent::getHelpPrompts()
+{
+	std::vector<HelpPrompt> ret;
+	ret.push_back(HelpPrompt("a", "select"));
+	return ret;
+}
+
+void VideoPlayerComponent::handleStartDelay()
+{
+	// Only play if any delay has timed out
+	if (mStartDelayed)
+	{
+		if (mStartTime > SDL_GetTicks())
+		{
+			// Timeout not yet completed
+			return;
+		}
+		// Completed
+		mStartDelayed = false;
+		// Clear the playing flag so startVideo works
+		mIsPlaying = false;
+		startVideo();
+	}
+}
+
+void VideoPlayerComponent::startVideo()
+{
+	if (!mIsPlaying) {
+		mVideoWidth = 0;
+		mVideoHeight = 0;
+
+#ifdef WIN32
+		std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> wton;
+		std::string path = wton.to_bytes(mVideoPath.c_str());
+#else
+		std::string path(mVideoPath.c_str());
+#endif
+		// Make sure we have a video path
+		if ((path.size() > 0) && (mPlayerPid == -1))
+		{
+			// Set the video that we are going to be playing so we don't attempt to restart it
+			mPlayingVideoPath = mVideoPath;
+
+			// Start the player process
+			pid_t pid = fork();
+			if (pid == -1)
+			{
+				// Failed
+				mPlayingVideoPath = "";
+			}
+			else if (pid > 0)
+				mPlayerPid = pid;
+			else
+			{
+				printf("Child\n");
+				const char* argv[] = { "", "-noborder", "-ao", "null", "-vo", "xv", "-display", ":0", "-geometry", "320x200+700+500", "/home/roy/tmp/MameVideosMkv/720.mkv", NULL };
+				const char* env[] = { NULL };
+				argv[10] = mPlayingVideoPath.c_str();
+				execve("/usr/bin/mplayer", (char**)argv, (char**)env);
+				_exit(EXIT_FAILURE);
+			}
+		}
+	}
+}
+
+void VideoPlayerComponent::startVideoWithDelay()
+{
+	// If not playing then either start the video or initiate the delay
+	if (!mIsPlaying)
+	{
+		// Set the video that we are going to be playing so we don't attempt to restart it
+		mPlayingVideoPath = mVideoPath;
+
+		if (mConfig.startDelay == 0)
+		{
+			// No delay. Just start the video
+			mStartDelayed = false;
+			startVideo();
+		}
+		else
+		{
+			// Configure the start delay
+			mStartDelayed = true;
+			mStartTime = SDL_GetTicks() + mConfig.startDelay;
+		}
+		mIsPlaying = true;
+	}
+}
+
+void VideoPlayerComponent::stopVideo()
+{
+	mIsPlaying = false;
+	mStartDelayed = false;
+
+	// Stop the player process
+	if (mPlayerPid != -1)
+	{
+		int status;
+		kill(mPlayerPid, SIGKILL);
+		waitpid(mPlayerPid, &status, WNOHANG);
+		mPlayerPid = -1;
+	}
+}
+
+void VideoPlayerComponent::update(int deltaTime)
+{
+	manageState();
+	handleStartDelay();
+	GuiComponent::update(deltaTime);
+}
+
+void VideoPlayerComponent::manageState()
+{
+	// We will only show if the component is on display
+	bool show = mShowing;
+
+	// See if we're already playing
+	if (mIsPlaying)
+	{
+		// If we are not on display then stop the video from playing
+		if (!show)
+		{
+			stopVideo();
+		}
+		else
+		{
+			if (mVideoPath != mPlayingVideoPath)
+			{
+				// Path changed. Stop the video. We will start it again below because
+				// mIsPlaying will be modified by stopVideo to be false
+				stopVideo();
+			}
+		}
+	}
+	// Need to recheck variable rather than 'else' because it may be modified above
+	if (!mIsPlaying)
+	{
+		// If we are on display then see if we should start the video
+		if (show && !mVideoPath.empty())
+		{
+			startVideoWithDelay();
+		}
+	}
+}
+
+void VideoPlayerComponent::onShow()
+{
+	mShowing = true;
+	manageState();
+}
+
+void VideoPlayerComponent::onHide()
+{
+	mShowing = false;
+	manageState();
+}
+
+

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -1,9 +1,13 @@
+#ifdef _RPI_
 #include "components/VideoPlayerComponent.h"
 #include "Renderer.h"
 #include "ThemeData.h"
 #include "Util.h"
 #include <signal.h>
 #include <wait.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 VideoPlayerComponent::VideoPlayerComponent(Window* window) :
 	VideoComponent(window),
@@ -62,6 +66,11 @@ void VideoPlayerComponent::startVideo()
 				const char* env[] = { "LD_LIBRARY_PATH=/opt/vc/libs:/usr/lib/omxplayer", NULL };
 				// Fill in the empty argument with the video path
 				argv[7] = mPlayingVideoPath.c_str();
+				// Redirect stdout
+				int fdin = open("/dev/null", O_RDONLY);
+				int fdout = open("/dev/null", O_WRONLY);
+				dup2(fdin, 0);
+				dup2(fdout, 1);
 				// Run the omxplayer binary
 				execve("/usr/bin/omxplayer.bin", (char**)argv, (char**)env);
 				_exit(EXIT_FAILURE);
@@ -84,4 +93,6 @@ void VideoPlayerComponent::stopVideo()
 		mPlayerPid = -1;
 	}
 }
+
+#endif
 

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -4,170 +4,20 @@
 #include "Util.h"
 #include <signal.h>
 #include <wait.h>
-#ifdef WIN32
-#include <codecvt>
-#endif
 
 VideoPlayerComponent::VideoPlayerComponent(Window* window) :
-	GuiComponent(window),
-	mStaticImage(window),
-	mVideoHeight(0),
-	mVideoWidth(0),
-	mStartDelayed(false),
-	mIsPlaying(false),
-	mShowing(false),
+	VideoComponent(window),
 	mPlayerPid(-1)
 {
-	// Setup the default configuration
-	mConfig.showSnapshotDelay 		= false;
-	mConfig.showSnapshotNoVideo		= false;
-	mConfig.startDelay				= 0;
 }
 
 VideoPlayerComponent::~VideoPlayerComponent()
 {
-	// Stop any currently running video
-	stopVideo();
-}
-
-void VideoPlayerComponent::setOrigin(float originX, float originY)
-{
-	mOrigin << originX, originY;
-
-	// Update the embeded static image
-	mStaticImage.setOrigin(originX, originY);
-}
-
-Eigen::Vector2f VideoPlayerComponent::getCenter() const
-{
-	return Eigen::Vector2f(mPosition.x() - (getSize().x() * mOrigin.x()) + getSize().x() / 2,
-		mPosition.y() - (getSize().y() * mOrigin.y()) + getSize().y() / 2);
-}
-
-void VideoPlayerComponent::onSizeChanged()
-{
-	// Update the embeded static image
-	mStaticImage.onSizeChanged();
-}
-
-bool VideoPlayerComponent::setVideo(std::string path)
-{
-	// Get the full native path
-	boost::filesystem::path fullPath = getCanonicalPath(path);
-	fullPath.make_preferred().native();
-
-	// Check that it's changed
-	if (fullPath == mVideoPath)
-		return !path.empty();
-
-	// Store the path
-	mVideoPath = fullPath;
-
-	// If the file exists then set the new video
-	if (!fullPath.empty() && ResourceManager::getInstance()->fileExists(fullPath.generic_string()))
-	{
-		// Return true to show that we are going to attempt to play a video
-		return true;
-	}
-	// Return false to show that no video will be displayed
-	return false;
-}
-
-void VideoPlayerComponent::setImage(std::string path)
-{
-	// Check that the image has changed
-	if (path == mStaticImagePath)
-		return;
-	
-	mStaticImage.setImage(path);
-	// Make the image stretch to fill the video region
-	mStaticImage.setSize(getSize());
-	mStaticImagePath = path;
-}
-
-void VideoPlayerComponent::setDefaultVideo()
-{
-	setVideo(mConfig.defaultVideoPath);
-}
-
-void VideoPlayerComponent::setOpacity(unsigned char opacity)
-{
-	// Update the embeded static image
-	mStaticImage.setOpacity(opacity);
 }
 
 void VideoPlayerComponent::render(const Eigen::Affine3f& parentTrans)
 {
-}
-
-void VideoPlayerComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties)
-{
-	using namespace ThemeFlags;
-
-	const ThemeData::ThemeElement* elem = theme->getElement(view, element, "video");
-	if(!elem)
-	{
-		return;
-	}
-
-	Eigen::Vector2f scale = getParent() ? getParent()->getSize() : Eigen::Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
-
-	if ((properties & POSITION) && elem->has("pos"))
-	{
-		Eigen::Vector2f denormalized = elem->get<Eigen::Vector2f>("pos").cwiseProduct(scale);
-		setPosition(Eigen::Vector3f(denormalized.x(), denormalized.y(), 0));
-	}
-
-	if ((properties & ThemeFlags::SIZE) && elem->has("size"))
-	{
-		setSize(elem->get<Eigen::Vector2f>("size").cwiseProduct(scale));
-	}
-
-	// position + size also implies origin
-	if (((properties & ORIGIN) || ((properties & POSITION) && (properties & ThemeFlags::SIZE))) && elem->has("origin"))
-		setOrigin(elem->get<Eigen::Vector2f>("origin"));
-
-	if(elem->has("default"))
-		mConfig.defaultVideoPath = elem->get<std::string>("default");
-
-	if((properties & ThemeFlags::DELAY) && elem->has("delay"))
-		mConfig.startDelay = (unsigned)(elem->get<float>("delay") * 1000.0f);
-
-	if (elem->has("showSnapshotNoVideo"))
-		mConfig.showSnapshotNoVideo = elem->get<bool>("showSnapshotNoVideo");
-
-	if (elem->has("showSnapshotDelay"))
-		mConfig.showSnapshotDelay = elem->get<bool>("showSnapshotDelay");
-
-	// Update the embeded static image
-	mStaticImage.setPosition(getPosition());
-	mStaticImage.setMaxSize(getSize());
-	mStaticImage.setSize(getSize());
-}
-
-std::vector<HelpPrompt> VideoPlayerComponent::getHelpPrompts()
-{
-	std::vector<HelpPrompt> ret;
-	ret.push_back(HelpPrompt("a", "select"));
-	return ret;
-}
-
-void VideoPlayerComponent::handleStartDelay()
-{
-	// Only play if any delay has timed out
-	if (mStartDelayed)
-	{
-		if (mStartTime > SDL_GetTicks())
-		{
-			// Timeout not yet completed
-			return;
-		}
-		// Completed
-		mStartDelayed = false;
-		// Clear the playing flag so startVideo works
-		mIsPlaying = false;
-		startVideo();
-	}
+	VideoComponent::render(parentTrans);
 }
 
 void VideoPlayerComponent::startVideo()
@@ -176,12 +26,8 @@ void VideoPlayerComponent::startVideo()
 		mVideoWidth = 0;
 		mVideoHeight = 0;
 
-#ifdef WIN32
-		std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> wton;
-		std::string path = wton.to_bytes(mVideoPath.c_str());
-#else
 		std::string path(mVideoPath.c_str());
-#endif
+
 		// Make sure we have a video path
 		if ((path.size() > 0) && (mPlayerPid == -1))
 		{
@@ -198,47 +44,29 @@ void VideoPlayerComponent::startVideo()
 			else if (pid > 0)
 			{
 				mPlayerPid = pid;
+				// Update the playing state
+				mIsPlaying = true;
+				mFadeIn = 0.0f;
 			}
 			else
 			{
+				// Find out the pixel position of the video view and build a command line for
+				// omxplayer to position it in the right place
+				char buf[32];
 				float x = mPosition.x() - (mOrigin.x() * mSize.x());
 				float y = mPosition.y() - (mOrigin.y() * mSize.y());
-				char buf[512];
 				sprintf(buf, "%d,%d,%d,%d", (int)x, (int)y, (int)(x + mSize.x()), (int)(y + mSize.y()));
-
+				// We need to specify the layer of 10000 or above to ensure the video is displayed on top
+				// of our SDL display
 				const char* argv[] = { "", "--win", buf, "--layer", "10000", "--loop", "--no-osd", "", NULL };
-				//const char* argv[] = { "", "-noborder", "-ao", "null", "-vo", "xv", "-display", ":0", "-geometry", "320x200+700+500", "/home/roy/tmp/MameVideosMkv/720.mkv", NULL };
 				const char* env[] = { "LD_LIBRARY_PATH=/opt/vc/libs:/usr/lib/omxplayer", NULL };
+				// Fill in the empty argument with the video path
 				argv[7] = mPlayingVideoPath.c_str();
+				// Run the omxplayer binary
 				execve("/usr/bin/omxplayer.bin", (char**)argv, (char**)env);
-				//execve("/usr/bin/mplayer", (char**)argv, (char**)env);
 				_exit(EXIT_FAILURE);
 			}
 		}
-	}
-}
-
-void VideoPlayerComponent::startVideoWithDelay()
-{
-	// If not playing then either start the video or initiate the delay
-	if (!mIsPlaying)
-	{
-		// Set the video that we are going to be playing so we don't attempt to restart it
-		mPlayingVideoPath = mVideoPath;
-
-		if (mConfig.startDelay == 0)
-		{
-			// No delay. Just start the video
-			mStartDelayed = false;
-			startVideo();
-		}
-		else
-		{
-			// Configure the start delay
-			mStartDelayed = true;
-			mStartTime = SDL_GetTicks() + mConfig.startDelay;
-		}
-		mIsPlaying = true;
 	}
 }
 
@@ -255,58 +83,5 @@ void VideoPlayerComponent::stopVideo()
 		waitpid(mPlayerPid, &status, WNOHANG);
 		mPlayerPid = -1;
 	}
-}
-
-void VideoPlayerComponent::update(int deltaTime)
-{
-	manageState();
-	handleStartDelay();
-	GuiComponent::update(deltaTime);
-}
-
-void VideoPlayerComponent::manageState()
-{
-	// We will only show if the component is on display
-	bool show = mShowing;
-
-	// See if we're already playing
-	if (mIsPlaying)
-	{
-		// If we are not on display then stop the video from playing
-		if (!show)
-		{
-			stopVideo();
-		}
-		else
-		{
-			if (mVideoPath != mPlayingVideoPath)
-			{
-				// Path changed. Stop the video. We will start it again below because
-				// mIsPlaying will be modified by stopVideo to be false
-				stopVideo();
-			}
-		}
-	}
-	// Need to recheck variable rather than 'else' because it may be modified above
-	if (!mIsPlaying)
-	{
-		// If we are on display then see if we should start the video
-		if (show && !mVideoPath.empty())
-		{
-			startVideoWithDelay();
-		}
-	}
-}
-
-void VideoPlayerComponent::onShow()
-{
-	mShowing = true;
-	manageState();
-}
-
-void VideoPlayerComponent::onHide()
-{
-	mShowing = false;
-	manageState();
 }
 

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -9,15 +9,10 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-std::string getTitlePath() {
-	std::string home = getHomePath();
-	return home + "/.emulationstation/last_title.txt";
-}
-
-VideoPlayerComponent::VideoPlayerComponent(Window* window, bool useSubtitles) :
+VideoPlayerComponent::VideoPlayerComponent(Window* window, const char* subtitleFolder) :
 	VideoComponent(window),
 	mPlayerPid(-1),
-	subtitles(useSubtitles)
+	subtitles(subtitleFolder)
 {
 }
 
@@ -75,7 +70,7 @@ void VideoPlayerComponent::startVideo()
 				if (subtitles) 
 				{	
 					argv[7] = "--subtitles";
-					argv[8] = getTitlePath().c_str();
+					argv[8] = subtitles;
 					argv[9] = mPlayingVideoPath.c_str();
 					/*argv[10] = "--no-ghost-box";
 					argv[11] = "--align"; 

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -17,6 +17,7 @@ VideoPlayerComponent::VideoPlayerComponent(Window* window) :
 
 VideoPlayerComponent::~VideoPlayerComponent()
 {
+	stopVideo();
 }
 
 void VideoPlayerComponent::render(const Eigen::Affine3f& parentTrans)

--- a/es-core/src/components/VideoPlayerComponent.h
+++ b/es-core/src/components/VideoPlayerComponent.h
@@ -4,90 +4,24 @@
 #include "platform.h"
 #include GLHEADER
 
-#include "GuiComponent.h"
-#include "ImageComponent.h"
-#include <string>
-#include <memory>
-#include <boost/filesystem.hpp>
+#include "components/VideoComponent.h"
 
-class VideoPlayerComponent : public GuiComponent
+class VideoPlayerComponent : public VideoComponent
 {
-	// Structure that groups together the configuration of the video component
-	struct Configuration
-	{
-		unsigned						startDelay;
-		bool							showSnapshotNoVideo;
-		bool							showSnapshotDelay;
-		std::string						defaultVideoPath;
-	};
-
 public:
 	VideoPlayerComponent(Window* window);
 	virtual ~VideoPlayerComponent();
 
-	// Loads the video at the given filepath
-	bool setVideo(std::string path);
-	// Loads a static image that is displayed if the video cannot be played
-	void setImage(std::string path);
-
-	// Configures the component to show the default video
-	void setDefaultVideo();
-	
-	virtual void onShow() override;
-	virtual void onHide() override;
-
-	//Sets the origin as a percentage of this image (e.g. (0, 0) is top left, (0.5, 0.5) is the center)
-	void setOrigin(float originX, float originY);
-	inline void setOrigin(Eigen::Vector2f origin) { setOrigin(origin.x(), origin.y()); }
-
-	void onSizeChanged() override;
-	void setOpacity(unsigned char opacity) override;
-
 	void render(const Eigen::Affine3f& parentTrans) override;
-
-	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
-
-	virtual std::vector<HelpPrompt> getHelpPrompts() override;
-
-	// Returns the center point of the video (takes origin into account).
-	Eigen::Vector2f getCenter() const;
-
-	virtual void update(int deltaTime);
 
 private:
 	// Start the video Immediately
-	void startVideo();
-	// Start the video after any configured delay
-	void startVideoWithDelay();
+	virtual void startVideo();
 	// Stop the video
-	void stopVideo();
-
-	// Handle any delay to the start of playing the video clip. Must be called periodically
-	void handleStartDelay();
-
-	// Handle looping the video. Must be called periodically
-	void handleLooping();
-
-	// Manage the playing state of the component
-	void manageState();
+	virtual void stopVideo();
 
 private:
-	unsigned						mVideoWidth;
-	unsigned						mVideoHeight;
-	Eigen::Vector2f 				mOrigin;
-	std::string						mStaticImagePath;
-	ImageComponent					mStaticImage;
-
 	pid_t							mPlayerPid;
-
-	boost::filesystem::path			mVideoPath;
-	boost::filesystem::path			mPlayingVideoPath;
-	bool							mStartDelayed;
-	unsigned						mStartTime;
-	bool							mIsPlaying;
-	bool							mShowing;
-
-	Configuration					mConfig;
 };
 
 #endif

--- a/es-core/src/components/VideoPlayerComponent.h
+++ b/es-core/src/components/VideoPlayerComponent.h
@@ -1,0 +1,93 @@
+#ifndef _VIDEOPLAYERCOMPONENT_H_
+#define _VIDEOPLAYERCOMPONENT_H_
+
+#include "platform.h"
+#include GLHEADER
+
+#include "GuiComponent.h"
+#include "ImageComponent.h"
+#include <string>
+#include <memory>
+#include <boost/filesystem.hpp>
+
+class VideoPlayerComponent : public GuiComponent
+{
+	// Structure that groups together the configuration of the video component
+	struct Configuration
+	{
+		unsigned						startDelay;
+		bool							showSnapshotNoVideo;
+		bool							showSnapshotDelay;
+		std::string						defaultVideoPath;
+	};
+
+public:
+	VideoPlayerComponent(Window* window);
+	virtual ~VideoPlayerComponent();
+
+	// Loads the video at the given filepath
+	bool setVideo(std::string path);
+	// Loads a static image that is displayed if the video cannot be played
+	void setImage(std::string path);
+
+	// Configures the component to show the default video
+	void setDefaultVideo();
+	
+	virtual void onShow() override;
+	virtual void onHide() override;
+
+	//Sets the origin as a percentage of this image (e.g. (0, 0) is top left, (0.5, 0.5) is the center)
+	void setOrigin(float originX, float originY);
+	inline void setOrigin(Eigen::Vector2f origin) { setOrigin(origin.x(), origin.y()); }
+
+	void onSizeChanged() override;
+	void setOpacity(unsigned char opacity) override;
+
+	void render(const Eigen::Affine3f& parentTrans) override;
+
+	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
+
+	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+
+	// Returns the center point of the video (takes origin into account).
+	Eigen::Vector2f getCenter() const;
+
+	virtual void update(int deltaTime);
+
+private:
+	// Start the video Immediately
+	void startVideo();
+	// Start the video after any configured delay
+	void startVideoWithDelay();
+	// Stop the video
+	void stopVideo();
+
+	// Handle any delay to the start of playing the video clip. Must be called periodically
+	void handleStartDelay();
+
+	// Handle looping the video. Must be called periodically
+	void handleLooping();
+
+	// Manage the playing state of the component
+	void manageState();
+
+private:
+	unsigned						mVideoWidth;
+	unsigned						mVideoHeight;
+	Eigen::Vector2f 				mOrigin;
+	std::string						mStaticImagePath;
+	ImageComponent					mStaticImage;
+
+	pid_t							mPlayerPid;
+
+	boost::filesystem::path			mVideoPath;
+	boost::filesystem::path			mPlayingVideoPath;
+	bool							mStartDelayed;
+	unsigned						mStartTime;
+	bool							mIsPlaying;
+	bool							mShowing;
+
+	Configuration					mConfig;
+};
+
+#endif

--- a/es-core/src/components/VideoPlayerComponent.h
+++ b/es-core/src/components/VideoPlayerComponent.h
@@ -10,7 +10,7 @@
 class VideoPlayerComponent : public VideoComponent
 {
 public:
-	VideoPlayerComponent(Window* window, const char* subtitleFolder);
+	VideoPlayerComponent(Window* window, std::string subtitlePath);
 	virtual ~VideoPlayerComponent();
 
 	void render(const Eigen::Affine3f& parentTrans) override;
@@ -23,7 +23,7 @@ private:
 
 private:
 	pid_t							mPlayerPid;
-	const char*						subtitles;
+	std::string						subtitles;
 };
 
 #endif

--- a/es-core/src/components/VideoPlayerComponent.h
+++ b/es-core/src/components/VideoPlayerComponent.h
@@ -1,3 +1,4 @@
+#ifdef _RPI_
 #ifndef _VIDEOPLAYERCOMPONENT_H_
 #define _VIDEOPLAYERCOMPONENT_H_
 
@@ -25,3 +26,5 @@ private:
 };
 
 #endif
+#endif
+

--- a/es-core/src/components/VideoPlayerComponent.h
+++ b/es-core/src/components/VideoPlayerComponent.h
@@ -10,7 +10,7 @@
 class VideoPlayerComponent : public VideoComponent
 {
 public:
-	VideoPlayerComponent(Window* window, std::string subtitlePath);
+	VideoPlayerComponent(Window* window, std::string path);
 	virtual ~VideoPlayerComponent();
 
 	void render(const Eigen::Affine3f& parentTrans) override;
@@ -23,7 +23,7 @@ private:
 
 private:
 	pid_t							mPlayerPid;
-	std::string						subtitles;
+	std::string						subtitlePath;
 };
 
 #endif

--- a/es-core/src/components/VideoPlayerComponent.h
+++ b/es-core/src/components/VideoPlayerComponent.h
@@ -7,12 +7,10 @@
 
 #include "components/VideoComponent.h"
 
-std::string getTitlePath();
-
 class VideoPlayerComponent : public VideoComponent
 {
 public:
-	VideoPlayerComponent(Window* window, bool useSubtitles);
+	VideoPlayerComponent(Window* window, const char* subtitleFolder);
 	virtual ~VideoPlayerComponent();
 
 	void render(const Eigen::Affine3f& parentTrans) override;
@@ -25,7 +23,7 @@ private:
 
 private:
 	pid_t							mPlayerPid;
-	bool							subtitles;
+	const char*						subtitles;
 };
 
 #endif

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -1,0 +1,247 @@
+#include "components/VideoVlcComponent.h"
+#include "Renderer.h"
+#include "ThemeData.h"
+#include "Util.h"
+#ifdef WIN32
+#include <codecvt>
+#endif
+
+libvlc_instance_t*		VideoVlcComponent::mVLC = NULL;
+
+// VLC prepares to render a video frame.
+static void *lock(void *data, void **p_pixels) {
+    struct VideoContext *c = (struct VideoContext *)data;
+    SDL_LockMutex(c->mutex);
+    SDL_LockSurface(c->surface);
+	*p_pixels = c->surface->pixels;
+    return NULL; // Picture identifier, not needed here.
+}
+
+// VLC just rendered a video frame.
+static void unlock(void *data, void *id, void *const *p_pixels) {
+    struct VideoContext *c = (struct VideoContext *)data;
+    SDL_UnlockSurface(c->surface);
+    SDL_UnlockMutex(c->mutex);
+}
+
+// VLC wants to display a video frame.
+static void display(void *data, void *id) {
+    //Data to be displayed
+}
+
+VideoVlcComponent::VideoVlcComponent(Window* window) :
+	VideoComponent(window),
+	mMediaPlayer(nullptr)
+{
+	memset(&mContext, 0, sizeof(mContext));
+
+	// Get an empty texture for rendering the video
+	mTexture = TextureResource::get("");
+
+	// Make sure VLC has been initialised
+	setupVLC();
+}
+
+VideoVlcComponent::~VideoVlcComponent()
+{
+}
+
+void VideoVlcComponent::render(const Eigen::Affine3f& parentTrans)
+{
+	VideoComponent::render(parentTrans);
+	float x, y;
+
+	Eigen::Affine3f trans = parentTrans * getTransform();
+	GuiComponent::renderChildren(trans);
+
+	Renderer::setMatrix(trans);
+	
+	if (mIsPlaying && mContext.valid)
+	{
+		float tex_offs_x = 0.0f;
+		float tex_offs_y = 0.0f;
+		float x2;
+		float y2;
+
+		x = -(float)mSize.x() * mOrigin.x();
+		y = -(float)mSize.y() * mOrigin.y();
+		x2 = x+mSize.x();
+		y2 = y+mSize.y();
+
+		// Define a structure to contain the data for each vertex
+		struct Vertex
+		{
+			Eigen::Vector2f pos;
+			Eigen::Vector2f tex;
+			Eigen::Vector4f colour;
+		} vertices[6];
+
+		// We need two triangles to cover the rectangular area
+		vertices[0].pos[0] = x; 			vertices[0].pos[1] = y;
+		vertices[1].pos[0] = x; 			vertices[1].pos[1] = y2;
+		vertices[2].pos[0] = x2;			vertices[2].pos[1] = y;
+
+		vertices[3].pos[0] = x2;			vertices[3].pos[1] = y;
+		vertices[4].pos[0] = x; 			vertices[4].pos[1] = y2;
+		vertices[5].pos[0] = x2;			vertices[5].pos[1] = y2;
+
+		// Texture coordinates
+		vertices[0].tex[0] = -tex_offs_x; 			vertices[0].tex[1] = -tex_offs_y;
+		vertices[1].tex[0] = -tex_offs_x; 			vertices[1].tex[1] = 1.0f + tex_offs_y;
+		vertices[2].tex[0] = 1.0f + tex_offs_x;		vertices[2].tex[1] = -tex_offs_y;
+
+		vertices[3].tex[0] = 1.0f + tex_offs_x;		vertices[3].tex[1] = -tex_offs_y;
+		vertices[4].tex[0] = -tex_offs_x;			vertices[4].tex[1] = 1.0f + tex_offs_y;
+		vertices[5].tex[0] = 1.0f + tex_offs_x;		vertices[5].tex[1] = 1.0f + tex_offs_y;
+
+		// Colours - use this to fade the video in and out
+		for (int i = 0; i < (4 * 6); ++i) {
+			if ((i%4) < 3)
+				vertices[i / 4].colour[i % 4] = mFadeIn;
+			else
+				vertices[i / 4].colour[i % 4] = 1.0f;
+		}
+
+		glEnable(GL_TEXTURE_2D);
+
+		// Build a texture for the video frame
+		mTexture->initFromPixels((unsigned char*)mContext.surface->pixels, mContext.surface->w, mContext.surface->h);
+		mTexture->bind();
+
+		// Render it
+		glEnableClientState(GL_COLOR_ARRAY);
+		glEnableClientState(GL_VERTEX_ARRAY);
+		glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+
+		glColorPointer(4, GL_FLOAT, sizeof(Vertex), &vertices[0].colour);
+		glVertexPointer(2, GL_FLOAT, sizeof(Vertex), &vertices[0].pos);
+		glTexCoordPointer(2, GL_FLOAT, sizeof(Vertex), &vertices[0].tex);
+
+		glDrawArrays(GL_TRIANGLES, 0, 6);
+
+		glDisableClientState(GL_VERTEX_ARRAY);
+		glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+		glDisableClientState(GL_COLOR_ARRAY);
+
+		glDisable(GL_TEXTURE_2D);
+	}
+}
+
+void VideoVlcComponent::setupContext()
+{
+	if (!mContext.valid)
+	{
+		// Create an RGBA surface to render the video into
+		mContext.surface = SDL_CreateRGBSurface(SDL_SWSURFACE, (int)mVideoWidth, (int)mVideoHeight, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
+		mContext.mutex = SDL_CreateMutex();
+		mContext.valid = true;
+	}
+}
+
+void VideoVlcComponent::freeContext()
+{
+	if (mContext.valid)
+	{
+		SDL_FreeSurface(mContext.surface);
+		SDL_DestroyMutex(mContext.mutex);
+		mContext.valid = false;
+	}
+}
+
+void VideoVlcComponent::setupVLC()
+{
+	// If VLC hasn't been initialised yet then do it now
+	if (!mVLC)
+	{
+		const char* args[] = { "--quiet" };
+		mVLC = libvlc_new(sizeof(args) / sizeof(args[0]), args);
+	}
+}
+
+void VideoVlcComponent::handleLooping()
+{
+	if (mIsPlaying && mMediaPlayer)
+	{
+		libvlc_state_t state = libvlc_media_player_get_state(mMediaPlayer);
+		if (state == libvlc_Ended)
+		{
+			//libvlc_media_player_set_position(mMediaPlayer, 0.0f);
+			libvlc_media_player_set_media(mMediaPlayer, mMedia);
+			libvlc_media_player_play(mMediaPlayer);
+		}
+	}
+}
+
+void VideoVlcComponent::startVideo()
+{
+	if (!mIsPlaying) {
+		mVideoWidth = 0;
+		mVideoHeight = 0;
+
+#ifdef WIN32
+		std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> wton;
+		std::string path = wton.to_bytes(mVideoPath.c_str());
+#else
+		std::string path(mVideoPath.c_str());
+#endif
+		// Make sure we have a video path
+		if (mVLC && (path.size() > 0))
+		{
+			// Set the video that we are going to be playing so we don't attempt to restart it
+			mPlayingVideoPath = mVideoPath;
+
+			// Open the media
+			mMedia = libvlc_media_new_path(mVLC, path.c_str());
+			if (mMedia)
+			{
+				unsigned 	track_count;
+				// Get the media metadata so we can find the aspect ratio
+				libvlc_media_parse(mMedia);
+				libvlc_media_track_t** tracks;
+				track_count = libvlc_media_tracks_get(mMedia, &tracks);
+				for (unsigned track = 0; track < track_count; ++track)
+				{
+					if (tracks[track]->i_type == libvlc_track_video)
+					{
+						mVideoWidth = tracks[track]->video->i_width;
+						mVideoHeight = tracks[track]->video->i_height;
+						break;
+					}
+				}
+				libvlc_media_tracks_release(tracks, track_count);
+
+				// Make sure we found a valid video track
+				if ((mVideoWidth > 0) && (mVideoHeight > 0))
+				{
+					setupContext();
+
+					// Setup the media player
+					mMediaPlayer = libvlc_media_player_new_from_media(mMedia);
+					libvlc_media_player_play(mMediaPlayer);
+					libvlc_video_set_callbacks(mMediaPlayer, lock, unlock, display, (void*)&mContext);
+					libvlc_video_set_format(mMediaPlayer, "RGBA", (int)mVideoWidth, (int)mVideoHeight, (int)mVideoWidth * 4);
+
+					// Update the playing state
+					mIsPlaying = true;
+					mFadeIn = 0.0f;
+				}
+			}
+		}
+	}
+}
+
+void VideoVlcComponent::stopVideo()
+{
+	mIsPlaying = false;
+	mStartDelayed = false;
+	// Release the media player so it stops calling back to us
+	if (mMediaPlayer)
+	{
+		libvlc_media_player_stop(mMediaPlayer);
+		libvlc_media_player_release(mMediaPlayer);
+		libvlc_media_release(mMedia);
+		mMediaPlayer = NULL;
+		freeContext();
+	}
+}
+

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -44,6 +44,7 @@ VideoVlcComponent::VideoVlcComponent(Window* window) :
 
 VideoVlcComponent::~VideoVlcComponent()
 {
+	stopVideo();
 }
 
 void VideoVlcComponent::render(const Eigen::Affine3f& parentTrans)

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -5,7 +5,6 @@
 #ifdef WIN32
 #include <codecvt>
 #endif
-#include "Log.h"
 
 libvlc_instance_t*		VideoVlcComponent::mVLC = NULL;
 
@@ -38,8 +37,6 @@ VideoVlcComponent::VideoVlcComponent(Window* window, std::string subtitles) :
 
 	// Get an empty texture for rendering the video
 	mTexture = TextureResource::get("");
-
-	LOG(LogDebug) << "Initializing VLC Player with Subtitles at: " << subtitles;
 
 	// Make sure VLC has been initialised
 	setupVLC(subtitles);
@@ -232,11 +229,6 @@ void VideoVlcComponent::startVideo()
 					// Setup the media player
 					mMediaPlayer = libvlc_media_player_new_from_media(mMedia);					
 
-					// add subtitles test
-					/*libvlc_media_slaves_clear(mMediaPlayer);
-					if(mSubtitles)
-						libvlc_media_slaves_add(mMediaPlayer, libvlc_media_slave_type_subtitle, 2, mSubtitles);
-					*/
 					libvlc_media_player_play(mMediaPlayer);
 					libvlc_video_set_callbacks(mMediaPlayer, lock, unlock, display, (void*)&mContext);
 					libvlc_video_set_format(mMediaPlayer, "RGBA", (int)mVideoWidth, (int)mVideoHeight, (int)mVideoWidth * 4);

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -29,9 +29,10 @@ static void display(void *data, void *id) {
     //Data to be displayed
 }
 
-VideoVlcComponent::VideoVlcComponent(Window* window) :
+VideoVlcComponent::VideoVlcComponent(Window* window, const char* subtitles) :
 	VideoComponent(window),
-	mMediaPlayer(nullptr)
+	mMediaPlayer(nullptr),
+	mSubtitles(subtitles)
 {
 	memset(&mContext, 0, sizeof(mContext));
 
@@ -217,7 +218,13 @@ void VideoVlcComponent::startVideo()
 					setupContext();
 
 					// Setup the media player
-					mMediaPlayer = libvlc_media_player_new_from_media(mMedia);
+					mMediaPlayer = libvlc_media_player_new_from_media(mMedia);					
+
+					// add subtitles test
+					libvlc_media_slaves_clear(mMediaPlayer);
+					if(mSubtitles)
+						libvlc_media_slaves_add(mMediaPlayer, libvlc_media_slave_type_subtitle, 2, mSubtitles);
+
 					libvlc_media_player_play(mMediaPlayer);
 					libvlc_video_set_callbacks(mMediaPlayer, lock, unlock, display, (void*)&mContext);
 					libvlc_video_set_format(mMediaPlayer, "RGBA", (int)mVideoWidth, (int)mVideoHeight, (int)mVideoWidth * 4);

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -1,0 +1,55 @@
+#ifndef _VIDEOVLCCOMPONENT_H_
+#define _VIDEOVLCCOMPONENT_H_
+
+#include "platform.h"
+#include GLHEADER
+
+#include "VideoComponent.h"
+#include <vlc/vlc.h>
+#include "resources/TextureResource.h"
+
+struct VideoContext {
+	SDL_Surface*		surface;
+	SDL_mutex*			mutex;
+	bool				valid;
+};
+
+class VideoVlcComponent : public VideoComponent
+{
+	// Structure that groups together the configuration of the video component
+	struct Configuration
+	{
+		unsigned						startDelay;
+		bool							showSnapshotNoVideo;
+		bool							showSnapshotDelay;
+		std::string						defaultVideoPath;
+	};
+
+public:
+	static void setupVLC();
+
+	VideoVlcComponent(Window* window);
+	virtual ~VideoVlcComponent();
+
+	void render(const Eigen::Affine3f& parentTrans) override;
+
+private:
+	// Start the video Immediately
+	virtual void startVideo();
+	// Stop the video
+	virtual void stopVideo();
+	// Handle looping the video. Must be called periodically
+	virtual void handleLooping();
+
+	void setupContext();
+	void freeContext();
+
+private:
+	static libvlc_instance_t*		mVLC;
+	libvlc_media_t*					mMedia;
+	libvlc_media_player_t*			mMediaPlayer;
+	VideoContext					mContext;
+	std::shared_ptr<TextureResource> mTexture;
+};
+
+#endif

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -28,7 +28,7 @@ class VideoVlcComponent : public VideoComponent
 public:
 	static void setupVLC();
 
-	VideoVlcComponent(Window* window);
+	VideoVlcComponent(Window* window, const char* subtitles);
 	virtual ~VideoVlcComponent();
 
 	void render(const Eigen::Affine3f& parentTrans) override;
@@ -50,6 +50,7 @@ private:
 	libvlc_media_player_t*			mMediaPlayer;
 	VideoContext					mContext;
 	std::shared_ptr<TextureResource> mTexture;
+	const char*						mSubtitles;
 };
 
 #endif

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -6,6 +6,7 @@
 
 #include "VideoComponent.h"
 #include <vlc/vlc.h>
+#include <vlc/libvlc_media.h>
 #include "resources/TextureResource.h"
 
 struct VideoContext {
@@ -26,9 +27,9 @@ class VideoVlcComponent : public VideoComponent
 	};
 
 public:
-	static void setupVLC();
+	static void setupVLC(std::string subtitles);
 
-	VideoVlcComponent(Window* window, const char* subtitles);
+	VideoVlcComponent(Window* window, std::string subtitles);
 	virtual ~VideoVlcComponent();
 
 	void render(const Eigen::Affine3f& parentTrans) override;
@@ -50,7 +51,6 @@ private:
 	libvlc_media_player_t*			mMediaPlayer;
 	VideoContext					mContext;
 	std::shared_ptr<TextureResource> mTexture;
-	const char*						mSubtitles;
 };
 
 #endif

--- a/es-core/src/platform.h
+++ b/es-core/src/platform.h
@@ -18,6 +18,7 @@
 #include <string>
 
 std::string getHomePath();
+std::string getTempPath();
 
 int runShutdownCommand(); // shut down the system (returns 0 if successful)
 int runRestartCommand(); // restart the system (returns 0 if successful)


### PR DESCRIPTION
Pressing "select" in the System Select menu launches screensaver. It's an option in the menu, so it can be disabled, and only works for if "Random Video" is the selected screensaver. Help menu updates accordingly.
Added "right" during video screensaver to select new random video, and "start" to launch it (or just navigate to the gamelist position where it currently is). These are options in the menu, and can be disabled.
Added the OMX Player option in the menu (it's called "Use Experimental Player" - the default is VLC, which means it defaults to OFF) so we can change it on the fly.
Added game name and system on screensaver, and option in menu. If enabled, it will show the game title and system as a subtitle for the first 5 seconds of the video screensaver, and the last 5 seconds as well.
Fixed the legacy screensavers (dim and black) that had stopped working with the recent screensaver refactoring. Hopefully I haven't brought about new problems.

Changes from previous release:

Keep aspect ratio for videos in OMXPlayer. Vertical games are no longer stretched. Haven't fixed it for VLC yet, but may look into it in the future.
Made OMXPlayer the default screensaver player for the RPi. VLC is still the default player for the themes.